### PR TITLE
fix: disable ktlint for the docker build step

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -23,3 +23,9 @@ jobs:
 
       - name: Run Build
         run: ./gradlew build
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        run: docker build -t pillarbox-monitoring-transfer .

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY gradle.properties .
 COPY build.gradle.kts .
 COPY src ./src
-RUN gradle clean build -x test -x detekt
+RUN gradle clean build -x test -x check
 
 # Second stage: Slim runtime image with optimized settings
 FROM eclipse-temurin:22-jre-alpine


### PR DESCRIPTION
## Description

Fix docker build by disabling the ktlint check in the docker build step.

## Changes Made

- Disabled all gradle checks inside the docker build step
- Added a check for docker build in the CI

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.