### PR TITLE
ci: fix release workflow when no version is produced

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,13 +48,22 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npx semantic-release
-          VERSION=$(cat VERSION)
-          echo "Resolved version: $VERSION"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Check version
+        id: check_version
+        run: |
+          if [ -f VERSION ]; then
+            VERSION=$(cat VERSION)
+            echo "Resolved version: $VERSION"
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+          else
+            echo "No version produced."
+            echo "version=" >> $GITHUB_OUTPUT
 
   deploy:
     runs-on: ubuntu-latest
     needs: release
+    if: needs.release.outputs.version != ''  # Skip deploy if no version is set
     permissions:
       id-token: write
     env:


### PR DESCRIPTION
## Description

Skip deploy step when there is no version produced by semantic release.

## Changes Made

- Added a condition to skip the deploy step when no version is produced.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
