### PR TITLE
ci: add stable promotion workflow and dev deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,45 @@
+name: Promote Version to Stable
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Enter the version tag to promote as stable (e.g., v1.0.0)"
+        required: true
+        type: string
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    env:
+      ECR_REGISTRY: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.GH_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Pull the selected version of the image
+        run: |
+          docker pull ${{ env.ECR_REGISTRY }}/pillarbox-monitoring-transfer:${{ github.event.inputs.version }}
+
+      - name: Tag the image as stable
+        run: |
+          docker tag ${{ env.ECR_REGISTRY }}/pillarbox-monitoring-transfer:${{ github.event.inputs.version }} ${{ env.ECR_REGISTRY }}/pillarbox-monitoring-transfer:stable
+          docker push ${{ env.ECR_REGISTRY }}/pillarbox-monitoring-transfer:stable
+
+      - name: ECS deployment
+        run: >
+          aws ecs update-service \
+            --cluster pillarbox-monitoring \
+            --service data-transfer-service \
+            --force-new-deployment \
+            --region ${{ secrets.AWS_REGION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
             echo "version=" >> $GITHUB_OUTPUT
           fi
 
-  deploy:
+  publish:
     runs-on: ubuntu-latest
     needs: release
     if: needs.release.outputs.version != ''  # Skip deploy if no version is set
@@ -74,7 +74,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: configure AWS credentials
+      - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.GH_ROLE }}
@@ -91,3 +91,24 @@ jobs:
           tags: |
             ${{ env.ECR_REGISTRY }}/pillarbox-monitoring-transfer:${{ needs.release.outputs.version }}
             ${{ env.ECR_REGISTRY }}/pillarbox-monitoring-transfer:latest
+
+  deploy-dev:
+    runs-on: ubuntu-latest
+    needs: publish
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.GH_DEV_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: ECS deployment
+        run: >
+          aws ecs update-service \
+            --cluster pillarbox-monitoring \
+            --service data-transfer-service \
+            --force-new-deployment \
+            --region ${{ secrets.AWS_REGION }}


### PR DESCRIPTION
## Description

Introduces a new workflow for promoting specific image versions to stable in ECR, followed by an ECS update in production. It also adds an automatic deployment to the development environment after each release

## Changes Made

- Add workflow to tag images as stable in ECR and update ECS service in production.
- Add workflow for automatic deployment to dev after each release.
- Rename `deploy` job to `publish` in `release.yml` for clarity.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
