### PR TITLE
feat: flag bot user agents

### DIFF
--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/model/EventRequest.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/model/EventRequest.kt
@@ -64,6 +64,15 @@ private class DataDeserializer : JsonDeserializer<Any?>() {
         .build()
   }
 
+  fun isHackerOrRobot(userAgent: UserAgent): Boolean =
+    listOf(UserAgent.DEVICE_CLASS, UserAgent.LAYOUT_ENGINE_CLASS, UserAgent.AGENT_CLASS, UserAgent.AGENT_SECURITY)
+      .any { field ->
+        userAgent.getValue(field)?.let { value ->
+          value.startsWith("Hacker", ignoreCase = true) ||
+            value.startsWith("Robot", ignoreCase = true)
+        } ?: false
+      }
+
   override fun deserialize(
     parser: JsonParser,
     ctxt: DeserializationContext,
@@ -79,26 +88,28 @@ private class DataDeserializer : JsonDeserializer<Any?>() {
     node.set<ObjectNode>(
       "browser",
       browserNode.apply {
-        put("name", userAgent.getValueOrNull("AgentName"))
-        put("version", userAgent.getValueOrNull("AgentVersion"))
+        put("name", userAgent.getValueOrNull(UserAgent.AGENT_NAME))
+        put("version", userAgent.getValueOrNull(UserAgent.AGENT_VERSION))
       },
     )
 
     node.set<ObjectNode>(
       "device",
       ObjectNode(ctxt.nodeFactory).apply {
-        put("name", userAgent.getValueOrNull("DeviceName"))
-        put("version", userAgent.getValueOrNull("DeviceVersion"))
+        put("name", userAgent.getValueOrNull(UserAgent.DEVICE_NAME))
+        put("version", userAgent.getValueOrNull(UserAgent.DEVICE_VERSION))
       },
     )
 
     node.set<ObjectNode>(
       "os",
       ObjectNode(ctxt.nodeFactory).apply {
-        put("name", userAgent.getValueOrNull("OperatingSystemName"))
-        put("version", userAgent.getValueOrNull("OperatingSystemVersion"))
+        put("name", userAgent.getValueOrNull(UserAgent.OPERATING_SYSTEM_NAME))
+        put("version", userAgent.getValueOrNull(UserAgent.OPERATING_SYSTEM_VERSION))
       },
     )
+
+    node.put("robot", isHackerOrRobot(userAgent))
 
     return parser.codec.treeToValue(node, Any::class.java)
   }

--- a/src/test/kotlin/ch/srgssr/pillarbox/monitoring/event/model/EventRequestTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/monitoring/event/model/EventRequestTest.kt
@@ -32,6 +32,7 @@ class EventRequestTest(
 
       // Then: The user agent data should have been resolved
       val dataNode = eventRequest.data as Map<*, *>
+      dataNode["robot"] shouldBe false
 
       val browserNode = dataNode["browser"] as Map<*, *>
       browserNode["name"] shouldBe "Chrome"
@@ -43,6 +44,42 @@ class EventRequestTest(
       val osNode = dataNode["os"] as Map<*, *>
       osNode["name"] shouldBe "Mac OS"
       osNode["version"] shouldBe ">=10.15.7"
+    }
+
+    should("deserialize an event and flag robot agents") {
+      // Given: an input with a user agent
+      val jsonInput =
+        """
+        {
+          "session_id": "12345",
+          "event_name": "START",
+          "timestamp": 1630000000000,
+          "version": 1,
+          "data": {
+            "browser": {
+              "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15 (Applebot/0.1; +http://www.apple.com/go/applebot)"
+            }
+          }
+        }
+        """.trimIndent()
+
+      // When: the event is deserialized
+      val eventRequest = objectMapper.readValue<EventRequest>(jsonInput)
+
+      // Then: The user agent data should have been resolved
+      val dataNode = eventRequest.data as Map<*, *>
+      dataNode["robot"] shouldBe true
+
+      val browserNode = dataNode["browser"] as Map<*, *>
+      browserNode["name"] shouldBe "Applebot"
+      browserNode["version"] shouldBe "0.1"
+
+      val deviceNode = dataNode["device"] as Map<*, *>
+      deviceNode["name"] shouldBe "Apple BOT"
+
+      val osNode = dataNode["os"] as Map<*, *>
+      osNode["name"] shouldBe "Cloud"
+      osNode["version"] shouldBe null
     }
 
     should("retain existing data when deserializing an event without user agent") {


### PR DESCRIPTION
## Description

Resolves #11 by identifying bot user agents and flagging them for filtering in later reports. This allows us to retain bot data for analysis rather than dropping it outright.

## Changes Made

- Marked bot-related events with a `robot` flag for downstream filtering
- Implemented test to validate bot detection and flagging functionality

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
