### PR TITLE
fix: update alias creation method and url for compatibility

### DIFF
--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/setup/AliasSetupTask.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/setup/AliasSetupTask.kt
@@ -48,7 +48,7 @@ class AliasSetupTask(
     /**
      * Path to create the alias in OpenSearch.
      */
-    private const val ALIAS_CREATION_PATH = "/_aliases/${ALIAS_NAME}"
+    private const val ALIAS_CREATION_PATH = "/_aliases"
   }
 
   /**
@@ -76,7 +76,7 @@ class AliasSetupTask(
   private fun createAlias(): Mono<*> {
     val indexTemplateJson = resourceLoader.loadResourceContent("classpath:opensearch/alias.json")
     return webClient
-      .put()
+      .post()
       .uri(ALIAS_CREATION_PATH)
       .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
       .bodyValue(indexTemplateJson)

--- a/src/test/kotlin/ch/srgssr/pillarbox/monitoring/event/setup/AliasSetupTaskTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/monitoring/event/setup/AliasSetupTaskTest.kt
@@ -60,7 +60,7 @@ class AliasSetupTaskTest(
         createDispatcher(
           mapOf(
             "GET" to "/_alias/user_events" to MockResponse().setResponseCode(404),
-            "PUT" to "/_aliases/user_events" to MockResponse().setResponseCode(201),
+            "POST" to "/_aliases" to MockResponse().setResponseCode(201),
           ),
         )
 
@@ -76,8 +76,8 @@ class AliasSetupTaskTest(
       }
 
       mockWebServer.takeRequest().apply {
-        path shouldBe "/_aliases/user_events"
-        method shouldBe "PUT"
+        path shouldBe "/_aliases"
+        method shouldBe "POST"
         shouldNotThrow<Exception> { objectMapper.readTree(body.readUtf8()) }
       }
     }


### PR DESCRIPTION
## Description

Updated the REST API method for creating aliases from PUT to POST and changed the URL from `_aliases/<alias_name>` to `_aliases` to align with OpenSearch v2.17 requirements.

## Changes Made

- Updated the alias setup task.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
