### PR TITLE
fix: add block reason mapping

### DIFF
--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/model/ErrorProcessor.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/model/ErrorProcessor.kt
@@ -111,6 +111,7 @@ internal enum class ContentRestriction(
     listOf(
       "This content is not available yet.",
       "This content is not yet available. Please try again later.",
+      "Dieser Inhalt ist noch nicht verfügbar.",
       "Dieser Inhalt ist noch nicht verfügbar. Bitte probieren Sie es später noch einmal.",
       "Ce contenu n'est pas encore disponible. Veuillez réessayer plus tard.",
       "Il contenuto non è ancora disponibile. Per cortesia prova più tardi.",


### PR DESCRIPTION
## Description

Added `Dieser Inhalt ist noch nicht verfügbar`to the list of possible START_DATE content restriction messages.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
