### PR TITLE
fix: add android specific error message for content restriction mapping

### DIFF
--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/model/ErrorProcessor.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/model/ErrorProcessor.kt
@@ -133,7 +133,10 @@ internal enum class ContentRestriction(
     private val messageToTypeMap: Map<String, ContentRestriction> by lazy {
       entries
         .flatMap { type ->
-          type.messages.map { message -> message to type }
+          buildList {
+            addAll(type.messages.map { message -> message to type })
+            add(Pair(type.name, type))
+          }
         }.toMap()
     }
 


### PR DESCRIPTION
## Description

Add android specific error message for content restriction mapping.

## Changes Made

- Error messages that use the block reason key as a message are now correctly mapped.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
