### PR TITLE
chore: enable full-text search on data.log field

### DIFF
--- a/src/main/resources/opensearch/index_template.json
+++ b/src/main/resources/opensearch/index_template.json
@@ -86,8 +86,7 @@
               "type": "long"
             },
             "log": {
-              "type": "keyword",
-              "ignore_above": 256
+              "type": "text"
             },
             "media": {
               "properties": {


### PR DESCRIPTION
## Description

Resolves #29 by changing the type of the data.log field from `keyword` to `text` to enable full-text search. This change also removes the limit on the number of characters that are searchable for the field.

## Changes Made

- Updated the index template.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
