### PR TITLE
chore: add application field to index template

### DIFF
--- a/src/main/resources/opensearch/index_template.json
+++ b/src/main/resources/opensearch/index_template.json
@@ -38,6 +38,18 @@
             "airplay": {
               "type": "boolean"
             },
+            "application": {
+              "properties": {
+                "id": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                },
+                "version": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            },
             "bandwidth": {
               "type": "long"
             },
@@ -225,6 +237,18 @@
         },
         "session": {
           "properties": {
+            "application": {
+              "properties": {
+                "id": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                },
+                "version": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            },
             "browser": {
               "properties": {
                 "name": {


### PR DESCRIPTION
## Description

Resolves #31 by adding an `application` field to the index template.

## Changes Made

The field that has been added contains 2 properties:

- `id`: a keyword of that matches up to 256 characters.
- `version`: a keyword of that matches up to 256 characters.

This new field is added both under `data` and `session` so that it can be matched for any kind of event.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
