### PR TITLE
feat: align start event indexed structure with other events

### DIFF
--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/EventDispatcherClient.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/EventDispatcherClient.kt
@@ -77,6 +77,10 @@ class EventDispatcherClient(
           events
             .filter { it.eventName == "START" }
             .onEach { sessionCache.put(it.sessionId, it.data) }
+            .onEach {
+              it.session = it.data
+              it.data = emptyMap<String, Any>()
+            }
 
         val nonStartEvents =
           events

--- a/src/main/resources/opensearch/alias.json
+++ b/src/main/resources/opensearch/alias.json
@@ -7,7 +7,6 @@
         "filter": {
           "bool": {
             "must_not": [
-              { "term": { "data.robot": true } },
               { "term": { "session.robot": true } }
             ]
           }

--- a/src/main/resources/opensearch/index_template.json
+++ b/src/main/resources/opensearch/index_template.json
@@ -38,58 +38,14 @@
             "airplay": {
               "type": "boolean"
             },
-            "application": {
-              "properties": {
-                "id": {
-                  "type": "keyword",
-                  "ignore_above": 256
-                },
-                "version": {
-                  "type": "keyword",
-                  "ignore_above": 256
-                }
-              }
-            },
             "bandwidth": {
               "type": "long"
             },
             "bitrate": {
               "type": "long"
             },
-            "browser": {
-              "properties": {
-                "name": {
-                  "type": "keyword",
-                  "ignore_above": 256
-                },
-                "user_agent": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "version": {
-                  "type": "keyword",
-                  "ignore_above": 256
-                }
-              }
-            },
             "buffered_duration": {
               "type": "long"
-            },
-            "device": {
-              "properties": {
-                "id": {
-                  "type": "keyword",
-                  "ignore_above": 256
-                },
-                "model": {
-                  "type": "keyword",
-                  "ignore_above": 256
-                },
-                "type": {
-                  "type": "keyword",
-                  "ignore_above": 256
-                }
-              }
             },
             "duration": {
               "type": "long"
@@ -99,27 +55,6 @@
             },
             "log": {
               "type": "text"
-            },
-            "media": {
-              "properties": {
-                "asset_url": {
-                  "type": "keyword",
-                  "ignore_above": 2048
-                },
-                "id": {
-                  "type": "keyword",
-                  "ignore_above": 256,
-                  "eager_global_ordinals": true
-                },
-                "metadata_url": {
-                  "type": "keyword",
-                  "ignore_above": 2048
-                },
-                "origin": {
-                  "type": "keyword",
-                  "ignore_above": 256
-                }
-              }
             },
             "message": {
               "type": "keyword",
@@ -136,71 +71,14 @@
               "type": "keyword",
               "ignore_above": 256
             },
-            "os": {
-              "properties": {
-                "name": {
-                  "type": "keyword",
-                  "ignore_above": 256
-                },
-                "version": {
-                  "type": "keyword",
-                  "ignore_above": 256
-                }
-              }
-            },
             "playback_duration": {
               "type": "long"
-            },
-            "player": {
-              "properties": {
-                "name": {
-                  "type": "keyword",
-                  "ignore_above": 256
-                },
-                "platform": {
-                  "type": "keyword",
-                  "ignore_above": 256
-                },
-                "version": {
-                  "type": "keyword",
-                  "ignore_above": 256
-                }
-              }
             },
             "position": {
               "type": "long"
             },
             "position_timestamp": {
               "type": "long"
-            },
-            "qoe_timings": {
-              "properties": {
-                "asset": {
-                  "type": "float"
-                },
-                "metadata": {
-                  "type": "float"
-                },
-                "total": {
-                  "type": "float"
-                }
-              }
-            },
-            "qos_timings": {
-              "properties": {
-                "asset": {
-                  "type": "float"
-                },
-                "metadata": {
-                  "type": "float"
-                },
-                "token": {
-                  "type": "float"
-                }
-              }
-            },
-            "robot": {
-              "type": "boolean"
             },
             "screen": {
               "properties": {


### PR DESCRIPTION
## Description

This change eliminates duplicate fields in the `data` object, reducing index size and simplifying queries. Previously, queries had to handle `data` for `START` events separately from `session` for other events. Now, all queries can target `session.<field>` uniformly.

## Changes Made

BREAKING CHANGE: Dashboards and queries relying on `data.<field>` for `START` events must be updated to use`session.<field>` instead.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
