### PR TITLE
feat: classify errors based on log field

### DIFF
--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/model/BlockReasonProcessor.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/model/BlockReasonProcessor.kt
@@ -1,0 +1,148 @@
+package ch.srgssr.pillarbox.monitoring.event.model
+
+/**
+ * A processor that determines whether an error message corresponds to a known content restriction type
+ * and annotates the data node with an appropriate classification.
+ */
+internal class ContentRestrictionProcessor : DataProcessor {
+  /**
+   * Process only on ERROR events.
+   */
+  override fun shouldProcess(
+    eventName: String,
+    data: Map<String, Any?>,
+  ): Boolean = eventName == "ERROR"
+
+  /**
+   * Processes the given data node to determine the block reason based on its message:
+   *
+   * If the message matches a predefined content restriction category, a `block_reason` field is added
+   * and the error is flagged as a business error.
+   *
+   * @param data The data node to process.
+   *
+   * @return The enriched data node with additional error classification.
+   */
+  override fun process(data: MutableMap<String, Any?>): MutableMap<String, Any?> {
+    val type =
+      (data["message"] as? String)?.let {
+        ContentRestriction.findByMessage(it)
+      }
+
+    data["block_reason"] = type?.name
+    data["business_error"] = type != null
+
+    return data
+  }
+}
+
+/**
+ * Enum representing different content restriction types based on predefined error messages.
+ */
+internal enum class ContentRestriction(
+  val messages: List<String>,
+) {
+  AGERATING12(
+    listOf(
+      "To protect children this content is only available between 8PM and 6AM.",
+      "To protect children, this content is only available between 8PM and 6AM.",
+      "Aus Gründen des Jugendschutzes steht dieser Inhalt nur zwischen 20:00 und 06:00 Uhr zur Verfügung.",
+      "Pour protéger les enfants, ce contenu est accessible entre 20h et 6h.",
+      "Per proteggere i bambini, questo media è disponibile solo fra le 20 e le 6.",
+      "Per proteger uffants, è quest cuntegn disponibel mo tranter las 20.00 e las 06.00.",
+    ),
+  ),
+  AGERATING18(
+    listOf(
+      "To protect children this content is only available between 10PM and 5AM.",
+      "To protect children, this content is only available between 11PM and 5AM.",
+      "Aus Gründen des Jugendschutzes steht dieser Inhalt nur zwischen 23:00 und 05:00 Uhr zur Verfügung.",
+      "Pour protéger les enfants, ce contenu est accessible entre 23h et 5h.",
+      "Per proteggere i bambini, questo media è disponibile solo fra le 23 le 5.",
+      "Per proteger uffants, è quest cuntegn disponibel mo tranter las 23.00 e las 05.00.",
+    ),
+  ),
+  COMMERCIAL(
+    listOf(
+      "This commercial content is not available.",
+      "This commercial media is not available.",
+      "Die Werbung wurde übersprungen.",
+      "Ce contenu n'est actuellement pas disponible.",
+      "Questo contenuto commerciale non è disponibile.",
+      "Quest medium commerzial n'è betg disponibel.",
+    ),
+  ),
+  ENDDATE(
+    listOf(
+      "This content is not available anymore.",
+      "Dieser Inhalt ist nicht mehr verfügbar.",
+      "Ce contenu n'est plus disponible.",
+      "Questo media non è più disponibile.",
+      "Quest cuntegn n'è betg pli disponibel.",
+    ),
+  ),
+  GEOBLOCK(
+    listOf(
+      "This content is not available outside Switzerland.",
+      "Dieser Inhalt ist ausserhalb der Schweiz nicht verfügbar.",
+      "La RTS ne dispose pas des droits de diffusion en dehors de la Suisse.",
+      "Questo media non è disponibile fuori dalla Svizzera.",
+      "Questo contenuto non è disponibile fuori dalla Svizzera.",
+      "Quest cuntegn n'è betg disponibel ordaifer la Svizra.",
+    ),
+  ),
+  JOURNALISTIC(
+    listOf(
+      "This content is temporarily unavailable for journalistic reasons.",
+      "Dieser Inhalt steht aus publizistischen Gründen vorübergehend nicht zur Verfügung.",
+      "Ce contenu est temporairement indisponible pour des raisons éditoriales.",
+      "Questo contenuto è temporaneamente non disponibile per motivi editoriali.",
+      "Quest cuntegn na stat ad interim betg a disposiziun per motivs publicistics.",
+    ),
+  ),
+  LEGAL(
+    listOf(
+      "This content is not available due to legal restrictions.",
+      "Dieser Inhalt ist aus rechtlichen Gründen nicht verfügbar.",
+      "Pour des raisons juridiques, ce contenu n'est pas disponible.",
+      "Il contenuto non è fruibile a causa di restrizioni legali.",
+      "Quest cuntegn n'è betg disponibel perquai ch'el è scadì.",
+    ),
+  ),
+  STARTDATE(
+    listOf(
+      "This content is not available yet.",
+      "This content is not yet available. Please try again later.",
+      "Dieser Inhalt ist noch nicht verfügbar.",
+      "Dieser Inhalt ist noch nicht verfügbar. Bitte probieren Sie es später noch einmal.",
+      "Ce contenu n'est pas encore disponible. Veuillez réessayer plus tard.",
+      "Il contenuto non è ancora disponibile. Per cortesia prova più tardi.",
+      "Questo contenuto non è ancora disponibile.",
+      "Quest cuntegn n'è betg anc disponibel. Empruvai pli tard.",
+    ),
+  ),
+  UNKNOWN(
+    listOf(
+      "This content is not available.",
+      "Dieser Inhalt ist nicht verfügbar.",
+      "Ce contenu n'est actuellement pas disponible.",
+      "Questo media non è disponibile.",
+      "Quest cuntegn n'è betg disponibel.",
+    ),
+  ),
+  ;
+
+  companion object {
+    private val messageToTypeMap: Map<String, ContentRestriction> by lazy {
+      entries
+        .flatMap { type ->
+          buildList {
+            addAll(type.messages.map { message -> message to type })
+            add(Pair(type.name, type))
+          }
+        }.toMap()
+    }
+
+    fun findByMessage(message: String): ContentRestriction? = messageToTypeMap[message]
+  }
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/model/DataProcessor.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/model/DataProcessor.kt
@@ -22,8 +22,12 @@ internal interface DataProcessor {
    * Implementations can override this method to specify which event types they should handle.
    *
    * @param eventName The name of the event being processed.
+   * @param data The processed data so far.
    *
    * @return `true` if the processor should handle this event, `false` otherwise.
    */
-  fun shouldProcess(eventName: String): Boolean = true
+  fun shouldProcess(
+    eventName: String,
+    data: Map<String, Any?>,
+  ): Boolean = true
 }

--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/model/ErrorProcessor.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/model/ErrorProcessor.kt
@@ -1,147 +1,91 @@
 package ch.srgssr.pillarbox.monitoring.event.model
 
 /**
- * A processor that identifies and categorizes error messages found in an error data node.
- *
- * This processor determines whether an error message corresponds to a known content restriction type
+ * A processor that determines whether an error log corresponds to a known error category
  * and annotates the data node with an appropriate classification.
  */
 internal class ErrorProcessor : DataProcessor {
   /**
-   * Process only on ERROR events.
+   * Process only on ERROR events and only those that are not content restricted.
    */
-  override fun shouldProcess(eventName: String): Boolean = eventName == "ERROR"
+  override fun shouldProcess(
+    eventName: String,
+    data: Map<String, Any?>,
+  ): Boolean = eventName == "ERROR" && (data["business_error"] as? Boolean != true)
 
   /**
-   * Processes the given data node to determine the type of error based on its message:
+   * Processes the given data node to determine the type of error based on the logs:
    *
-   * If the message matches a predefined content restriction category, an `error_type` field is added
-   * and the error is flagged as a business error.
+   * If the log matches a predefined error category, an `error_type` field is added to the data.
    *
    * @param data The data node to process.
    *
    * @return The enriched data node with additional error classification.
    */
   override fun process(data: MutableMap<String, Any?>): MutableMap<String, Any?> {
-    val type =
-      (data["message"] as? String)?.let {
-        ContentRestriction.findByMessage(it)
-      }
-
+    val type = (data["log"] as? String)?.let { PlayerErrorType.find(it) }
     data["error_type"] = type?.name
-    data["business_error"] = type != null
-
     return data
   }
 }
 
 /**
- * Enum representing different content restriction types based on predefined error messages.
+ * Enum representing various error categories.
  */
-internal enum class ContentRestriction(
-  val messages: List<String>,
+internal enum class PlayerErrorType(
+  pattern: String,
 ) {
-  AGERATING12(
-    listOf(
-      "To protect children this content is only available between 8PM and 6AM.",
-      "To protect children, this content is only available between 8PM and 6AM.",
-      "Aus Gründen des Jugendschutzes steht dieser Inhalt nur zwischen 20:00 und 06:00 Uhr zur Verfügung.",
-      "Pour protéger les enfants, ce contenu est accessible entre 20h et 6h.",
-      "Per proteggere i bambini, questo media è disponibile solo fra le 20 e le 6.",
-      "Per proteger uffants, è quest cuntegn disponibel mo tranter las 20.00 e las 06.00.",
-    ),
-  ),
-  AGERATING18(
-    listOf(
-      "To protect children this content is only available between 10PM and 5AM.",
-      "To protect children, this content is only available between 11PM and 5AM.",
-      "Aus Gründen des Jugendschutzes steht dieser Inhalt nur zwischen 23:00 und 05:00 Uhr zur Verfügung.",
-      "Pour protéger les enfants, ce contenu est accessible entre 23h et 5h.",
-      "Per proteggere i bambini, questo media è disponibile solo fra le 23 le 5.",
-      "Per proteger uffants, è quest cuntegn disponibel mo tranter las 23.00 e las 05.00.",
-    ),
-  ),
-  COMMERCIAL(
-    listOf(
-      "This commercial content is not available.",
-      "This commercial media is not available.",
-      "Die Werbung wurde übersprungen.",
-      "Ce contenu n'est actuellement pas disponible.",
-      "Questo contenuto commerciale non è disponibile.",
-      "Quest medium commerzial n'è betg disponibel.",
-    ),
-  ),
-  ENDDATE(
-    listOf(
-      "This content is not available anymore.",
-      "Dieser Inhalt ist nicht mehr verfügbar.",
-      "Ce contenu n'est plus disponible.",
-      "Questo media non è più disponibile.",
-      "Quest cuntegn n'è betg pli disponibel.",
-    ),
-  ),
-  GEOBLOCK(
-    listOf(
-      "This content is not available outside Switzerland.",
-      "Dieser Inhalt ist ausserhalb der Schweiz nicht verfügbar.",
-      "La RTS ne dispose pas des droits de diffusion en dehors de la Suisse.",
-      "Questo media non è disponibile fuori dalla Svizzera.",
-      "Questo contenuto non è disponibile fuori dalla Svizzera.",
-      "Quest cuntegn n'è betg disponibel ordaifer la Svizra.",
-    ),
-  ),
-  JOURNALISTIC(
-    listOf(
-      "This content is temporarily unavailable for journalistic reasons.",
-      "Dieser Inhalt steht aus publizistischen Gründen vorübergehend nicht zur Verfügung.",
-      "Ce contenu est temporairement indisponible pour des raisons éditoriales.",
-      "Questo contenuto è temporaneamente non disponibile per motivi editoriali.",
-      "Quest cuntegn na stat ad interim betg a disposiziun per motivs publicistics.",
-    ),
-  ),
-  LEGAL(
-    listOf(
-      "This content is not available due to legal restrictions.",
-      "Dieser Inhalt ist aus rechtlichen Gründen nicht verfügbar.",
-      "Pour des raisons juridiques, ce contenu n'est pas disponible.",
-      "Il contenuto non è fruibile a causa di restrizioni legali.",
-      "Quest cuntegn n'è betg disponibel perquai ch'el è scadì.",
-    ),
-  ),
-  STARTDATE(
-    listOf(
-      "This content is not available yet.",
-      "This content is not yet available. Please try again later.",
-      "Dieser Inhalt ist noch nicht verfügbar.",
-      "Dieser Inhalt ist noch nicht verfügbar. Bitte probieren Sie es später noch einmal.",
-      "Ce contenu n'est pas encore disponible. Veuillez réessayer plus tard.",
-      "Il contenuto non è ancora disponibile. Per cortesia prova più tardi.",
-      "Questo contenuto non è ancora disponibile.",
-      "Quest cuntegn n'è betg anc disponibel. Empruvai pli tard.",
-    ),
-  ),
-  UNKNOWN(
-    listOf(
-      "This content is not available.",
-      "Dieser Inhalt ist nicht verfügbar.",
-      "Ce contenu n'est actuellement pas disponible.",
-      "Questo media non è disponibile.",
-      "Quest cuntegn n'è betg disponibel.",
-    ),
-  ),
+  /**
+   * Failure when calling the Integration Layer API.
+   */
+  IL_ERROR("il\\.srgssr\\.ch"),
+
+  /**
+   * The device or browser does not support the required DRM mechanism.
+   */
+  DRM_NOT_SUPPORTED("ERROR_DRM_NOT_SUPPORTED_MESSAGE"),
+
+  /**
+   * Failure to decrypt or decode DRM-protected content.
+   */
+  DRM_ERROR("MEDIA_ERR_ENCRYPTED"),
+
+  /**
+   * Error loading or decoding the media resource.
+   */
+  PLAYBACK_MEDIA_SOURCE_ERROR("MEDIA_ERR_DECODE"),
+
+  /**
+   * The media format is not supported on the current device or browser.
+   */
+  PLAYBACK_UNSUPPORTED_MEDIA("MEDIA_ERR_SRC_NOT_SUPPORTED"),
+
+  /**
+   * A network error occurred during playback.
+   */
+  PLAYBACK_NETWORK_ERROR("MEDIA_ERR_NETWORK"),
+
+  /**
+   * Any error that does not fall into the above categories.
+   */
+  UNKNOWN_ERROR(".*"),
   ;
 
-  companion object {
-    private val messageToTypeMap: Map<String, ContentRestriction> by lazy {
-      entries
-        .flatMap { type ->
-          buildList {
-            addAll(type.messages.map { message -> message to type })
-            add(Pair(type.name, type))
-          }
-        }.toMap()
-    }
+  val pattern = Regex(pattern)
 
-    fun findByMessage(message: String): ContentRestriction? = messageToTypeMap[message]
+  companion object {
+    fun find(str: String): PlayerErrorType =
+      PlayerErrorType
+        .entries
+        .filter { it != UNKNOWN_ERROR }
+        .mapNotNull { type ->
+          type.pattern
+            .findAll(str)
+            .lastOrNull()
+            ?.range
+            ?.first
+            ?.let { index -> type to index }
+        }.maxByOrNull { it.second }
+        ?.first ?: UNKNOWN_ERROR
   }
 }

--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/model/EventRequestDataConverter.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/model/EventRequestDataConverter.kt
@@ -13,14 +13,17 @@ import com.fasterxml.jackson.databind.util.StdConverter
  * @see [DataProcessor]
  */
 internal class EventRequestDataConverter : StdConverter<EventRequest, EventRequest>() {
-  private val processors = listOf(UserAgentProcessor(), ErrorProcessor())
+  private val processors = listOf(UserAgentProcessor(), ContentRestrictionProcessor(), ErrorProcessor())
 
   @Suppress("UNCHECKED_CAST")
   override fun convert(value: EventRequest): EventRequest {
     (value.data as? MutableMap<String, Any?>)?.let { data ->
       processors
-        .filter { it.shouldProcess(value.eventName) }
-        .forEach { processor -> value.data = processor.process(data) }
+        .forEach { processor ->
+          if (processor.shouldProcess(value.eventName, data)) {
+            value.data = processor.process(data)
+          }
+        }
     }
 
     return value

--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/model/UserAgentProcessor.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/model/UserAgentProcessor.kt
@@ -32,7 +32,10 @@ internal class UserAgentProcessor : DataProcessor {
   /**
    * Process only on START events.
    */
-  override fun shouldProcess(eventName: String): Boolean = eventName == "START"
+  override fun shouldProcess(
+    eventName: String,
+    data: Map<String, Any?>,
+  ): Boolean = eventName == "START"
 
   /**
    * Processes the given data node to extract and enrich user agent details.

--- a/src/main/resources/opensearch/index_template.json
+++ b/src/main/resources/opensearch/index_template.json
@@ -64,6 +64,10 @@
               "type": "keyword",
               "ignore_above": 256
             },
+            "block_reason": {
+              "type": "keyword",
+              "ignore_above": 256
+            },
             "business_error": {
               "type": "boolean"
             },

--- a/src/test/kotlin/ch/srgssr/pillarbox/monitoring/event/model/ContentRestrictionProcessorTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/monitoring/event/model/ContentRestrictionProcessorTest.kt
@@ -1,0 +1,89 @@
+package ch.srgssr.pillarbox.monitoring.event.model
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ContentRestrictionProcessorTest(
+  private val objectMapper: ObjectMapper,
+) : ShouldSpec({
+    should("classify error messages correctly based on predefined content restrictions") {
+      // Given: an input with a predefined error message
+      val jsonInput =
+        """
+        {
+          "session_id": "12345",
+          "event_name": "ERROR",
+          "timestamp": 1630000000000,
+          "user_ip": "127.0.0.1",
+          "version": 1,
+          "data": {
+            "message": "This content is not available outside Switzerland."
+          }
+        }
+        """.trimIndent()
+
+      // When: the event is deserialized
+      val eventRequest = objectMapper.readValue<EventRequest>(jsonInput)
+
+      // Then: The error should be classified correctly
+      val dataNode = eventRequest.data as Map<*, *>
+      dataNode["block_reason"] shouldBe "GEOBLOCK"
+      dataNode["business_error"] shouldBe true
+    }
+
+    should("flag the error as not a business error if it doesn't match a predefined content restriction") {
+      // Given: an input with a non predefined error message
+      val jsonInput =
+        """
+        {
+          "session_id": "12345",
+          "event_name": "ERROR",
+          "timestamp": 1630000000000,
+          "user_ip": "127.0.0.1",
+          "version": 1,
+          "data": {
+            "message": "java.io.IOException"
+          }
+        }
+        """.trimIndent()
+
+      // When: the event is deserialized
+      val eventRequest = objectMapper.readValue<EventRequest>(jsonInput)
+
+      // Then: The error should be classified correctly
+      val dataNode = eventRequest.data as Map<*, *>
+      dataNode["block_reason"] shouldBe null
+      dataNode["business_error"] shouldBe false
+    }
+
+    should("not classify errors if the event is not of type \"ERROR\"") {
+      // Given: an input with a message of type "START"
+      val jsonInput =
+        """
+        {
+          "session_id": "12345",
+          "event_name": "START",
+          "timestamp": 1630000000000,
+          "user_ip": "127.0.0.1",
+          "version": 1,
+          "data": {
+            "message": "This content is not available outside Switzerland."
+          }
+        }
+        """.trimIndent()
+
+      // When: the event is deserialized
+      val eventRequest = objectMapper.readValue<EventRequest>(jsonInput)
+
+      // Then: The block reason should be classified correctly
+      val dataNode = eventRequest.data as Map<*, *>
+      dataNode["block_reason"] shouldBe null
+      dataNode["business_error"] shouldBe null
+    }
+  })

--- a/src/test/kotlin/ch/srgssr/pillarbox/monitoring/event/model/ErrorProcessorTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/monitoring/event/model/ErrorProcessorTest.kt
@@ -1,0 +1,89 @@
+package ch.srgssr.pillarbox.monitoring.event.model
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ErrorProcessorTest(
+  private val objectMapper: ObjectMapper,
+) : ShouldSpec({
+    should("classify error log correctly based on the predefined pattern") {
+      // Given: an input with a predefined error message
+      val jsonInput =
+        """
+        {
+          "session_id": "12345",
+          "event_name": "ERROR",
+          "timestamp": 1630000000000,
+          "user_ip": "127.0.0.1",
+          "version": 1,
+          "data": {
+            "log": "ERROR: Received ERROR_DRM_NOT_SUPPORTED_MESSAGE"
+          }
+        }
+        """.trimIndent()
+
+      // When: the event is deserialized
+      val eventRequest = objectMapper.readValue<EventRequest>(jsonInput)
+
+      // Then: The error should be classified correctly
+      val dataNode = eventRequest.data as Map<*, *>
+      dataNode["error_type"] shouldBe "DRM_NOT_SUPPORTED"
+    }
+
+    should("not classify errors if it's already flagged as a business error") {
+      // Given: an input with a non predefined error message
+      val jsonInput =
+        """
+        {
+          "session_id": "12345",
+          "event_name": "ERROR",
+          "timestamp": 1630000000000,
+          "user_ip": "127.0.0.1",
+          "version": 1,
+          "data": {
+            "message": "This content is not available outside Switzerland.",
+            "log": "ERROR: Received ERROR_DRM_NOT_SUPPORTED_MESSAGE"
+          }
+        }
+        """.trimIndent()
+
+      // When: the event is deserialized
+      val eventRequest = objectMapper.readValue<EventRequest>(jsonInput)
+
+      // Then: The error should be classified correctly
+      val dataNode = eventRequest.data as Map<*, *>
+      dataNode["block_reason"] shouldBe "GEOBLOCK"
+      dataNode["error_type"] shouldBe null
+      dataNode["business_error"] shouldBe true
+    }
+
+    should("not classify errors if the event is not of type \"ERROR\"") {
+      // Given: an input with a message of type "START"
+      val jsonInput =
+        """
+        {
+          "session_id": "12345",
+          "event_name": "START",
+          "timestamp": 1630000000000,
+          "user_ip": "127.0.0.1",
+          "version": 1,
+          "data": {
+            "log": "ERROR: Received ERROR_DRM_NOT_SUPPORTED_MESSAGE"
+          }
+        }
+        """.trimIndent()
+
+      // When: the event is deserialized
+      val eventRequest = objectMapper.readValue<EventRequest>(jsonInput)
+
+      // Then: The block reason should be classified correctly
+      val dataNode = eventRequest.data as Map<*, *>
+      dataNode["error_type"] shouldBe null
+    }
+  })

--- a/src/test/kotlin/ch/srgssr/pillarbox/monitoring/event/model/UserAgentProcessorTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/monitoring/event/model/UserAgentProcessorTest.kt
@@ -1,9 +1,7 @@
 package ch.srgssr.pillarbox.monitoring.event.model
 
-import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
 import org.springframework.boot.test.context.SpringBootTest
@@ -11,70 +9,9 @@ import org.springframework.test.context.ActiveProfiles
 
 @SpringBootTest
 @ActiveProfiles("test")
-class EventRequestTest(
+class UserAgentProcessorTest(
   private val objectMapper: ObjectMapper,
 ) : ShouldSpec({
-    should("deserialize successfully if all required fields are present") {
-      // Given: an event as json
-      val jsonInput =
-        """
-        {
-          "session_id": "12345",
-          "event_name": "START",
-          "timestamp": 1630000000000,
-          "user_ip": "127.0.0.1",
-          "version": 1,
-          "data": { }
-          }
-        }
-        """.trimIndent()
-
-      // When: the event is deserialized
-      val eventRequest = objectMapper.readValue<EventRequest>(jsonInput)
-
-      // Then: The data of the event should be correctly parsed.
-      eventRequest.sessionId shouldBe "12345"
-      eventRequest.eventName shouldBe "START"
-      eventRequest.timestamp shouldBe 1630000000000
-      eventRequest.ip shouldBe "127.0.0.1"
-      eventRequest.version shouldBe 1
-    }
-
-    context("fail to deserialize if missing any required field") {
-      val baseJson =
-        mapOf(
-          "session_id" to "\"12345\"",
-          "event_name" to "\"START\"",
-          "timestamp" to "1630000000000",
-          "version" to "1",
-          "data" to "{}",
-        )
-
-      baseJson.keys.forEach { missingField ->
-        should("fail if $missingField is missing") {
-          val jsonInput =
-            baseJson
-              .filterKeys { it != missingField } // Exclude the current field
-              .map { (key, value) -> "\"$key\": $value" }
-              .joinToString(prefix = "{", postfix = "}")
-
-          shouldThrow<JsonMappingException> {
-            objectMapper.readValue<EventRequest>(jsonInput)
-          }
-        }
-        should("fail if $missingField is null") {
-          val jsonInput =
-            baseJson
-              .map { (key, value) ->
-                "\"$key\": ${if (key == missingField) "null" else value}"
-              }.joinToString(prefix = "{", postfix = "}")
-
-          shouldThrow<JsonMappingException> {
-            objectMapper.readValue<EventRequest>(jsonInput)
-          }
-        }
-      }
-    }
 
     should("deserialize an event and resolve user agent") {
       // Given: an input with a user agent


### PR DESCRIPTION
## Description

Resolves #37 by introducing a new pattern‑based `ErrorProcessor` that matches error entries in the log payload and annotates events with the most recent error category.

## Changes Made

- Renamed the former `ErrorProcessor` to `BlockReasonProcessor`.
- Updated the index template to include a new `block_reason` field and map block reasons there instead of `error_type`.
- Implemented a new `ErrorProcessor` which scans the log string against known error patterns and selects the error match appearing furthest in the text, ensuring the latest error is captured.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
