### PR TITLE
feat: add vpn blocking reason detection

### DIFF
--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/model/BlockReasonProcessor.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/model/BlockReasonProcessor.kt
@@ -121,6 +121,19 @@ internal enum class ContentRestriction(
       "Quest cuntegn n'è betg anc disponibel. Empruvai pli tard.",
     ),
   ),
+  VPNORPROXYDETECTED(
+    listOf(
+      "This content cannot be played while using a VPN.",
+      "This content cannot be played while using a VPN or a proxy.",
+      "Dieser Inhalt ist mit VPN oder Proxy nicht abspielbar.",
+      "Dieser Inhalt ist mit aktiviertem VPN nicht abspielbar.",
+      "Ce contenu ne peut pas être lu avec un VPN ou un proxy.",
+      "Ce contenu ne peut pas être lu lorsque vous utilisez un VPN.",
+      "Questo contenuto non può essere riprodotto con VPN o proxy.",
+      "Questo contenuto non può essere riprodotto mentre si utilizza una VPN.",
+      "Quest cuntegn na po betg vegnir reproducì cun VPN ni proxy activà.",
+    ),
+  ),
   UNKNOWN(
     listOf(
       "This content is not available.",
@@ -138,7 +151,7 @@ internal enum class ContentRestriction(
         .flatMap { type ->
           buildList {
             addAll(type.messages.map { message -> message to type })
-            add(Pair(type.name, type))
+            add(type.name to type)
           }
         }.toMap()
     }

--- a/src/test/kotlin/ch/srgssr/pillarbox/monitoring/event/model/ErrorProcessorTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/monitoring/event/model/ErrorProcessorTest.kt
@@ -36,6 +36,30 @@ class ErrorProcessorTest(
       dataNode["error_type"] shouldBe "DRM_NOT_SUPPORTED"
     }
 
+    should("classify an error as unknown if no pattern matches") {
+      // Given: an input with a predefined error message
+      val jsonInput =
+        """
+        {
+          "session_id": "12345",
+          "event_name": "ERROR",
+          "timestamp": 1630000000000,
+          "user_ip": "127.0.0.1",
+          "version": 1,
+          "data": {
+            "log": "ERROR: Unexpected error occurred."
+          }
+        }
+        """.trimIndent()
+
+      // When: the event is deserialized
+      val eventRequest = objectMapper.readValue<EventRequest>(jsonInput)
+
+      // Then: The error should be classified correctly
+      val dataNode = eventRequest.data as Map<*, *>
+      dataNode["error_type"] shouldBe "UNKNOWN_ERROR"
+    }
+
     should("not classify errors if it's already flagged as a business error") {
       // Given: an input with a non predefined error message
       val jsonInput =


### PR DESCRIPTION
## Description

Resolves https://github.com/SRGSSR/pillarbox-monitoring-transfer/issues/43 by adding a new blocking reason for VPN and Proxy detection as reported by the players.

## Changes Made

- Added the `VPNPROXYDETECTED` block reason.
- Added a test case for unknown error detection.
- Minor style change.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
