### PR TITLE
Fix/update ism policy

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -124,13 +124,13 @@ osctl update-alias -h http://localhost:9200 -t '{...}'
 osctl force-rollover -h http://localhost:9200
 ```
 
-#### Update ISM Policy
+#### Update ISM Policy:
 
 ```bash
 osctl auto-update-ism-policy -h http://localhost:9200 -d '{...}'
 ```
 
-## Guidelines for Updating the index template
+## Guidelines for updating the index template
 
 When you update an index template in OpenSearch, changes are only applied to new indices. Existing
 indices will continue using the old configuration. Depending on your use case, you can choose
@@ -173,7 +173,7 @@ updating the alias to target it.
 Recommended for: Situations where changes must be applied without waiting for the scheduled
 rollover.
 
-## Guidelines for Updating the ISM Policy
+## Guidelines for updating the ISM Policy
 
 To update the `events_policy` ISM policy in OpenSearch, you need the current `seq_no` and
 `primary_term`. This ensures that the update is performed safely and correctly.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,7 +7,7 @@
 ## Installation
 
 To install `osctl`, follow these steps to set up a dedicated installation directory and run the
-install script. The `install-osctl.sh` script will:
+installation script. The `install-osctl.sh` script will:
 
 - Download the specified version from GitHub
 - Install it in a versioned folder (`<install_dir>/<version>/`)
@@ -15,7 +15,23 @@ install script. The `install-osctl.sh` script will:
 
 ### Step-by-Step Guide
 
-1. **Create a dedicated osctl directory**
+1. **Install required dependencies**
+
+   Before running the installation script, make sure you have `jq` and `curl` installed. These tools
+   are required to download and process data during installation.
+
+   * On **Debian/Ubuntu** and other apt-based systems:
+     ```bash
+     sudo apt update
+     sudo apt install -y curl jq
+     ```
+
+   * Or in a yum-based systems:
+     ```bash
+     sudo yum install -y curl jq
+     ```
+
+2. **Create a dedicated osctl directory**
 
    We recommend installing `osctl` in a hidden folder in your home directory for a clean setup. Open
    your terminal and run:
@@ -25,7 +41,7 @@ install script. The `install-osctl.sh` script will:
    cd ~/.osctl
    ```
 
-2. **Download the installation script**
+3. **Download the installation script**
 
    Download the [`install-osctl.sh`](./install-osctl.sh) script from the repo:
 
@@ -34,7 +50,7 @@ install script. The `install-osctl.sh` script will:
    chmod +x install-osctl.sh
    ```
 
-3. **Run the installer for your desired version**
+4. **Run the installer for your desired version**
 
    Replace `4.1.0` with the version you want. The script will download the asset from GitHub,
    install it into a versioned folder (e.g., `~/.osctl/4.1.0/`), and update the `current` symlink
@@ -44,7 +60,7 @@ install script. The `install-osctl.sh` script will:
    ./install-osctl.sh -v 4.1.0
    ```
 
-4. **Add osctl to your PATH (optional)**
+5. **Add osctl to your PATH (optional)**
 
    To easily run `osctl` from anywhere, add the following line to your shell configuration file (
    e.g., `~/.bashrc` or `~/.zshrc`):
@@ -59,7 +75,7 @@ install script. The `install-osctl.sh` script will:
    source ~/.bashrc   # or source ~/.zshrc
    ```
 
-5. **Run osctl**
+6. **Run osctl**
 
    Now you can run:
 
@@ -77,12 +93,16 @@ osctl <command> [options]
 
 - **update-template**: Updates the `events_template` index template.
   [Learn about index templates](http://opensearch.org/docs/latest/im-plugin/index-templates/)
-
 - **update-alias**: Updates the `user_events` alias with a new configuration.
   [Learn about index aliases](https://opensearch.org/docs/latest/im-plugin/index-alias/)
-
 - **force-rollover**: Forces an immediate rollover of the `events` index.
   [Learn about rollover actions](https://opensearch.org/docs/latest/im-plugin/ism/policies/#rollover-action)
+- **get-ism-seq**: Retrieves the current `seq_no` and `primary_term` of the `events_policy` ISM
+  policy.
+- **update-ism-policy**: Updates the `events_policy` ISM policy in OpenSearch.
+- **auto-update-ism-policy**: Automatically retrieves `seq_no` and `primary_term`, then updates the
+  `events_policy` ISM policy.
+  [Learn about ISM policies](https://docs.opensearch.org/docs/latest/im-plugin/ism/policies/)
 
 ## Examples
 
@@ -104,30 +124,119 @@ osctl update-alias -h http://localhost:9200 -t '{...}'
 osctl force-rollover -h http://localhost:9200
 ```
 
-## Guidelines for Updating a Template
+#### Update ISM Policy
+
+```bash
+osctl auto-update-ism-policy -h http://localhost:9200 -d '{...}'
+```
+
+## Guidelines for Updating the index template
+
+When you update an index template in OpenSearch, changes are only applied to new indices. Existing
+indices will continue using the old configuration. Depending on your use case, you can choose
+between a deferred or immediate application of the changes.
 
 ### If you can wait for the next rollover:
+
+This is the simplest and most common approach for non-urgent changes.
 
 1. Run:
    ```bash
    osctl update-template -h <opensearch_host> -t '{...}'
    ```
-2. The changes will take effect on the next rollover automatically.
+2. The updated template will be applied automatically the next time OpenSearch performs a rollover
+   and creates a new index.
+
+Recommended for: Routine updates that do not require immediate application (e.g., adding new
+optional fields, adjusting settings that are not critical to current data).
 
 ### If you need the change to take effect immediately:
+
+For cases where changes must be reflected without delay, follow this process:
 
 1. Update the template:
    ```bash
    osctl update-template -h <opensearch_host> -t '{...}'
    ```
-2. Force a rollover:
+2. Trigger an immediate rollover:
    ```bash
    osctl force-rollover -h <opensearch_host>
    ```
-3. Update the alias:
+3. Update the alias to point to the new index:
    ```bash
    osctl update-alias -h <opensearch_host> -t '{...}'
    ```
 
-This ensures that the new template is applied right away instead of waiting for the next automatic
+This sequence ensures that the new template is used right away by creating a fresh index and
+updating the alias to target it.
+
+Recommended for: Situations where changes must be applied without waiting for the scheduled
 rollover.
+
+## Guidelines for Updating the ISM Policy
+
+To update the `events_policy` ISM policy in OpenSearch, you need the current `seq_no` and
+`primary_term`. This ensures that the update is performed safely and correctly.
+
+There are two ways to do this:
+
+### 🔁 **Recommended: Automatic Update**
+
+This method uses the `auto-update-ism-policy` script, which retrieves the `seq_no` and
+`primary_term` automatically before applying the update.
+
+#### Usage
+
+```bash
+osctl auto-update-ism-policy -h <opensearch_host> -d '<policy_json>'
+```
+
+Replace `<opensearch_host>` with your OpenSearch URL (e.g., `http://localhost:9200`) and
+`<policy_json>` with your ISM policy definition.
+
+#### Example
+
+```bash
+osctl auto-update-ism-policy -h http://localhost:9200 -d '{...}'
+```
+
+This script will:
+
+1. Retrieve the current `seq_no` and `primary_term` of the `events_policy`.
+2. Call `update-ism-policy` with the correct values to apply the update.
+
+If anything goes wrong, you can fall back to the manual method below.
+
+### 🛠️ **Manual Update**
+
+If the automatic method fails, or you want full control, you can retrieve the metadata manually and
+then run the update yourself.
+
+#### Step 1: Retrieve `seq_no` and `primary_term`
+
+Use the helper script `get-ism-seq`:
+
+```bash
+osctl get-ism-seq -h <opensearch_host>
+```
+
+You will get an output like:
+
+```
+seq_no=42
+primary_term=3
+```
+
+#### Step 2: Apply the update using `update-ism-policy`
+
+Run the update script using the retrieved values:
+
+```bash
+osctl update-ism-policy -h <opensearch_host> -d '<policy_json>' -s <seq_no> -r <primary_term>
+```
+
+#### Example
+
+```bash
+osctl update-ism-policy -h http://localhost:9200 -d '{...}' -s 42 -r 3
+```

--- a/scripts/osctl/bin/auto-update-ism-policy
+++ b/scripts/osctl/bin/auto-update-ism-policy
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+unset OPENSEARCH_HOST
+unset POLICY_JSON
+
+source "$(dirname "$0")/../lib/logging.sh"
+
+# Usage function
+usage() {
+  warn "Usage: $0 -h <opensearch_host> -d <policy_json>"
+  echo ""
+  echo "This script automatically retrieves seq_no and primary_term, then updates the 'events_policy' ISM policy in OpenSearch."
+  echo ""
+  echo "Options:"
+  echo "  -h <opensearch_host>   The OpenSearch host URL (e.g., http://localhost:9200)"
+  echo "  -d <policy_json>       The JSON payload for the policy update"
+  echo ""
+  echo "Example:"
+  echo "  $0 -h http://localhost:9200 -d '{ ... }'"
+  echo ""
+  exit 1
+}
+
+# Parse arguments
+while getopts "h:d:" opt; do
+  case ${opt} in
+    h ) OPENSEARCH_HOST=$OPTARG ;;
+    d ) POLICY_JSON=$OPTARG ;;
+    * ) usage ;;
+  esac
+done
+
+# Check if required arguments are set
+if [ -z "$OPENSEARCH_HOST" ] || [ -z "$POLICY_JSON" ]; then
+  error "Error: All parameters are required."
+  usage
+fi
+
+SEQ_TERM_OUTPUT=$(
+  "$(dirname "$0")/get-ism-seq" -h "$OPENSEARCH_HOST" \
+    2>&1 | tee /dev/tty
+)
+SEQ_EXIT_CODE=$?
+
+# If the seq/primary term retrieval fails, exit the script
+if [[ SEQ_EXIT_CODE -ne 0 ]]; then
+  exit 1
+fi
+
+# Extract the seq_no and primary_term from the output of the first script
+SEQ_NO=$(echo "$SEQ_TERM_OUTPUT" | grep 'seq_no=' | cut -d '=' -f2)
+PRIMARY_TERM=$(echo "$SEQ_TERM_OUTPUT" | grep 'primary_term=' | cut -d '=' -f2)
+
+# Call the second script to update the policy, passing the retrieved values
+"$(dirname "$0")/update-ism-policy" -h "$OPENSEARCH_HOST" -d "$POLICY_JSON" -s "$SEQ_NO" -r "$PRIMARY_TERM"

--- a/scripts/osctl/bin/get-ism-seq
+++ b/scripts/osctl/bin/get-ism-seq
@@ -8,7 +8,7 @@ source "$(dirname "$0")/../lib/logging.sh"
 usage() {
   warn "Usage: $0 -h <opensearch_host>"
   echo ""
-  echo "This script forces an immediate rollover of the 'events' index in OpenSearch."
+  echo "This script retrieves the seq_no and primary_term for the 'events_policy' ISM policy."
   echo ""
   echo "Options:"
   echo "  -h <opensearch_host>   The OpenSearch host URL (e.g., http://localhost:9200)"
@@ -16,7 +16,6 @@ usage() {
   echo "Example:"
   echo "  $0 -h http://localhost:9200"
   echo ""
-  echo "This script is part of the monitoring setup and is used to force a rollover of the 'events' index, ensuring a new index is created."
   exit 1
 }
 
@@ -24,7 +23,7 @@ usage() {
 while getopts "h:" opt; do
   case ${opt} in
     h ) OPENSEARCH_HOST=$OPTARG ;;
-    * ) ;;
+    * ) usage ;;
   esac
 done
 
@@ -34,15 +33,9 @@ if [ -z "$OPENSEARCH_HOST" ]; then
   usage
 fi
 
+info "Retrieving seq_no and primary_term for policy 'events_policy'..."
 
-info "Forcing rollover..."
-ROLLOVER_RESPONSE=$(curl -s -X POST "$OPENSEARCH_HOST/events/_rollover" \
-  -H "Content-Type: application/json" \
-  -d '{
-        "conditions": {
-          "max_age": "0s"
-        }
-      }')
+GET_RESPONSE=$(curl -s -X GET "$OPENSEARCH_HOST/_plugins/_ism/policies/events_policy")
 CURL_EXIT_CODE=$?
 
 # Check if curl failed
@@ -51,11 +44,15 @@ if [ $CURL_EXIT_CODE -ne 0 ]; then
   exit 1
 fi
 
-# Check if rollover was successful
-if echo "$ROLLOVER_RESPONSE" | grep -q '"acknowledged":true'; then
-  success "Rollover completed successfully!"
-else
-  error "Error: Rollover failed. Response: $ROLLOVER_RESPONSE"
+SEQ_NO=$(echo "$GET_RESPONSE" | jq -r '._seq_no')
+PRIMARY_TERM=$(echo "$GET_RESPONSE" | jq -r '._primary_term')
+
+if [ "$SEQ_NO" == "null" ] || [ "$PRIMARY_TERM" == "null" ]; then
+  error "Error: Could not extract seq_no and primary_term. Response: $GET_RESPONSE"
   exit 1
 fi
 
+success "Retrieved successfully:"
+
+echo "seq_no=$SEQ_NO"
+echo "primary_term=$PRIMARY_TERM"

--- a/scripts/osctl/bin/update-alias
+++ b/scripts/osctl/bin/update-alias
@@ -70,3 +70,4 @@ else
   error "Error: Failed to create alias. Response: $CREATE_RESPONSE"
   exit 1
 fi
+

--- a/scripts/osctl/bin/update-alias
+++ b/scripts/osctl/bin/update-alias
@@ -2,6 +2,7 @@
 
 unset OPENSEARCH_HOST
 unset ALIAS_JSON
+
 source "$(dirname "$0")/../lib/logging.sh"
 
 # Usage function
@@ -63,9 +64,9 @@ if [ $CURL_EXIT_CODE -ne 0 ]; then
   exit 1
 fi
 
-if echo "$CREATE_RESPONSE" | grep -q 'error'; then
+if echo "$CREATE_RESPONSE" | grep -q '"acknowledged":true'; then
+  success "Alias updated successfully."
+else
   error "Error: Failed to create alias. Response: $CREATE_RESPONSE"
   exit 1
-else
-  success "Alias updated successfully."
 fi

--- a/scripts/osctl/bin/update-index-template
+++ b/scripts/osctl/bin/update-index-template
@@ -2,6 +2,7 @@
 
 unset OPENSEARCH_HOST
 unset TEMPLATE_JSON
+
 source "$(dirname "$0")/../lib/logging.sh"
 
 # Usage function

--- a/scripts/osctl/bin/update-ism-policy
+++ b/scripts/osctl/bin/update-ism-policy
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+unset OPENSEARCH_HOST
+unset POLICY_JSON
+unset SEQ_NO
+unset PRIMARY_TERM
+
+source "$(dirname "$0")/../lib/logging.sh"
+
+# Usage function
+usage() {
+  warn "Usage: $0 -h <opensearch_host> -d <policy_json> -s <seq_no> -r <primary_term>"
+  echo ""
+  echo "This script updates the 'events_policy' ISM policy in OpenSearch."
+  echo ""
+  echo "Options:"
+  echo "  -h <opensearch_host>   The OpenSearch host URL (e.g., http://localhost:9200)"
+  echo "  -d <policy_json>       The JSON payload for the policy"
+  echo "  -s <seq_no>            The sequence number (seq_no) of the existing policy"
+  echo "  -r <primary_term>      The primary term (primary_term) of the existing policy"
+  echo ""
+  echo "Example:"
+  echo "  $0 -h http://localhost:9200 -d '{ ... }' -s 3 -r 1"
+  echo ""
+  exit 1
+}
+
+# Parse arguments
+while getopts "h:d:s:r:" opt; do
+  case ${opt} in
+    h ) OPENSEARCH_HOST=$OPTARG ;;
+    d ) POLICY_JSON=$OPTARG ;;
+    s ) SEQ_NO=$OPTARG ;;
+    r ) PRIMARY_TERM=$OPTARG ;;
+    * ) usage ;;
+  esac
+done
+
+# Check if required arguments are set
+if [ -z "$OPENSEARCH_HOST" ] || [ -z "$POLICY_JSON" ] || [ -z "$SEQ_NO" ] || [ -z "$PRIMARY_TERM" ]; then
+  error "Error: All parameters are required."
+  usage
+fi
+
+info "Updating ISM policy 'events_policy'..."
+
+UPDATE_URL="$OPENSEARCH_HOST/_plugins/_ism/policies/events_policy?if_seq_no=$SEQ_NO&if_primary_term=$PRIMARY_TERM"
+UPDATE_RESPONSE=$(curl -s -X PUT "$UPDATE_URL" -H 'Content-Type: application/json' -d "$POLICY_JSON")
+CURL_EXIT_CODE=$?
+
+# Check if curl failed
+if [ $CURL_EXIT_CODE -ne 0 ]; then
+  error "Error: Unable to communicate with OpenSearch. Please check your connection."
+  exit 1
+fi
+
+
+# Check if template update was successful
+if echo "$RESPONSE" | grep -q '"error":{'; then
+  error "Error: Failed to update ISM policy. Response: $UPDATE_RESPONSE"
+  exit 1
+else
+  success "ISM policy updated successfully."
+fi

--- a/scripts/osctl/osctl
+++ b/scripts/osctl/osctl
@@ -7,9 +7,10 @@ usage() {
   warn "Usage: $0 <command> [options]"
   echo ""
   echo "Commands:"
-  echo "  update-template    Update the OpenSearch index template"
-  echo "  update-alias       Update the OpenSearch alias"
   echo "  force-rollover     Force rollover of the 'events' index"
+  echo "  update-alias       Update the OpenSearch alias"
+  echo "  update-template    Update the OpenSearch index template"
+  echo "  update-ism-policy  Update the ISM policy"
   echo ""
   echo "Example:"
   echo "  $0 update-alias -h http://localhost:9200 -t '{\"actions\":...}'"
@@ -43,20 +44,32 @@ shift  # Shift removes the first argument so the rest can be passed to the sub-s
 
 # Define script paths
 BIN_DIR="$(dirname "$0")/bin"  # Gets the directory of this script
-UPDATE_TEMPLATE_SCRIPT="$BIN_DIR/update-index-template"
-UPDATE_ALIAS_SCRIPT="$BIN_DIR/update-alias"
+AUTO_UPDATE_ISM_POLICY="$BIN_DIR/auto-update-ism-policy"
 FORCE_ROLLOVER_SCRIPT="$BIN_DIR/force-rollover"
+GET_ISM_SEQ="$BIN_DIR/get-ism-seq"
+UPDATE_ALIAS_SCRIPT="$BIN_DIR/update-alias"
+UPDATE_TEMPLATE_SCRIPT="$BIN_DIR/update-index-template"
+UPDATE_ISM_POLICY="$BIN_DIR/update-ism-policy"
 
 # Redirect to the appropriate script
 case "$COMMAND" in
-  update-template)
-    exec "$UPDATE_TEMPLATE_SCRIPT" "$@"
+  auto-update-ism-policy)
+    exec "$AUTO_UPDATE_ISM_POLICY" "$@"
+    ;;
+  force-rollover)
+    exec "$FORCE_ROLLOVER_SCRIPT" "$@"
+    ;;
+  get-ism-seq)
+    exec "$GET_ISM_SEQ" "$@"
     ;;
   update-alias)
     exec "$UPDATE_ALIAS_SCRIPT" "$@"
     ;;
-  force-rollover)
-    exec "$FORCE_ROLLOVER_SCRIPT" "$@"
+  update-template)
+    exec "$UPDATE_TEMPLATE_SCRIPT" "$@"
+    ;;
+  update-ism-policy)
+    exec "$UPDATE_ISM_POLICY" "$@"
     ;;
   *)
     error "Error: Invalid command '$COMMAND'"

--- a/src/main/resources/opensearch/ism_policy.json
+++ b/src/main/resources/opensearch/ism_policy.json
@@ -36,7 +36,7 @@
           {
             "state_name": "delete",
             "conditions": {
-              "min_index_age": "7d"
+              "min_index_age": "10d"
             }
           }
         ]


### PR DESCRIPTION
## Description

Resolves #46 by incrementing the number of days an index stays in the warm state to 10 days before it gets deleted.

## Changes Made

- Updated the `min_index_age` of the warm state of the `events_policy` to 10 days.
- Added `osctl` helper scripts to easily update an ISM policy. The following scripts are now available: 
  - **get-ism-seq**: Retrieves the current `seq_no` and `primary_term` of the `events_policy` ISM policy.
  - **update-ism-policy**: Updates the `events_policy` ISM policy in OpenSearch.
  - **auto-update-ism-policy**: Automatically retrieves `seq_no` and `primary_term`, then updates the `events_policy` ISM policy.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
