### PR TITLE
fix: make web client max-in-memory-size configurable

### DIFF
--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/repository/OpenSearchConfigurationProperties.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/repository/OpenSearchConfigurationProperties.kt
@@ -3,6 +3,7 @@ package ch.srgssr.pillarbox.monitoring.event.repository
 import ch.srgssr.pillarbox.monitoring.event.config.RetryProperties
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.NestedConfigurationProperty
+import org.springframework.util.unit.DataSize
 import java.net.URI
 
 /**
@@ -13,6 +14,8 @@ import java.net.URI
  * @property uri The URI of the OpenSearch server. Defaults to `http://localhost:9200`.
  * @property retry Nested configuration properties for retry settings related to OpenSearch operations.
  * @property timeout The default timeout for each connection in milliseconds. 10s by default.
+ * @property maxInMemorySize The maximum size in bytes allowed for buffering response bodies in memory,
+ *                           64 MB by default.
  */
 @ConfigurationProperties(prefix = "pillarbox.monitoring.opensearch")
 data class OpenSearchConfigurationProperties(
@@ -20,4 +23,5 @@ data class OpenSearchConfigurationProperties(
   @NestedConfigurationProperty
   val retry: RetryProperties = RetryProperties(),
   val timeout: Int = 10_000,
+  val maxInMemorySize: DataSize = DataSize.ofMegabytes(64),
 )

--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/setup/OpenSearchSetupConfiguration.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/setup/OpenSearchSetupConfiguration.kt
@@ -5,6 +5,7 @@ import io.netty.channel.ChannelOption
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.client.reactive.ReactorClientHttpConnector
+import org.springframework.web.reactive.function.client.ExchangeStrategies
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.netty.http.client.HttpClient
 
@@ -32,6 +33,14 @@ class OpenSearchSetupConfiguration {
       .builder()
       .baseUrl(properties.uri.toString())
       .clientConnector(ReactorClientHttpConnector(httpClient))
-      .build()
+      .exchangeStrategies(
+        ExchangeStrategies
+          .builder()
+          .codecs {
+            it.defaultCodecs().maxInMemorySize(
+              properties.maxInMemorySize.toBytes().toInt(),
+            )
+          }.build(),
+      ).build()
   }
 }


### PR DESCRIPTION
## Description

The default WebClient buffer (256 KB) was too small for large OpenSearch `_bulk` responses, causing `DataBufferLimitException`. This change makes `maxInMemorySize` configurable to safely handle bigger responses and prevent runtime errors.

The default value is 64MB.

## Changes Made

- Add a new configuration property to customise the `max-in-memory-size` for the OpenSearch web client.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
