### PR TITLE
feat: add ios error categorisation support

### DIFF
--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/model/ErrorProcessor.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/model/ErrorProcessor.kt
@@ -23,16 +23,19 @@ internal class ErrorProcessor : DataProcessor {
    * @return The enriched data node with additional error classification.
    */
   override fun process(data: MutableMap<String, Any?>): MutableMap<String, Any?> {
-    val type = (data["log"] as? String)?.let { PlayerErrorType.find(it) }
-    data["error_type"] = type?.name
+    data["error_type"] = listOf(
+      WebPlayerErrorType::find,
+      IOSPlayerErrorType::find,
+    ).firstNotNullOfOrNull { it(data) } ?: "UNKNOWN_ERROR"
+
     return data
   }
 }
 
 /**
- * Enum representing various error categories.
+ * Enum representing various error categories for the web player.
  */
-internal enum class PlayerErrorType(
+internal enum class WebPlayerErrorType(
   pattern: String,
 ) {
   /**
@@ -64,28 +67,62 @@ internal enum class PlayerErrorType(
    * A network error occurred during playback.
    */
   PLAYBACK_NETWORK_ERROR("MEDIA_ERR_NETWORK"),
-
-  /**
-   * Any error that does not fall into the above categories.
-   */
-  UNKNOWN_ERROR(".*"),
   ;
 
   val pattern = Regex(pattern)
 
   companion object {
-    fun find(str: String): PlayerErrorType =
-      PlayerErrorType
-        .entries
-        .filter { it != UNKNOWN_ERROR }
-        .mapNotNull { type ->
-          type.pattern
-            .findAll(str)
-            .lastOrNull()
-            ?.range
-            ?.first
-            ?.let { index -> type to index }
-        }.maxByOrNull { it.second }
-        ?.first ?: UNKNOWN_ERROR
+    fun find(data: MutableMap<String, Any?>): String? =
+      (data["log"] as? String)?.let { log ->
+        WebPlayerErrorType.entries
+          .mapNotNull { type ->
+            type.pattern
+              .findAll(log)
+              .lastOrNull()
+              ?.range
+              ?.first
+              ?.let { index -> type to index }
+          }.maxByOrNull { it.second }
+          ?.first
+          ?.name
+      }
+  }
+}
+
+/**
+ * Enum representing various error categories for the iOS player.
+ */
+internal enum class IOSPlayerErrorType(
+  vararg val matches: String,
+) {
+  /**
+   * Failure when calling the Integration Layer API.
+   */
+  IL_ERROR("PillarboxCoreBusiness.DataError(1)"),
+
+  /**
+   * Error loading or decoding the media resource.
+   */
+  PLAYBACK_MEDIA_SOURCE_ERROR(
+    "CoreMediaErrorDomain(1)",
+    "CoreMediaErrorDomain(-12648)",
+    "CoreMediaErrorDomain(-16839)",
+  ),
+
+  /**
+   * A network error occurred during playback.
+   */
+  PLAYBACK_NETWORK_ERROR("NSURLErrorDomain(-1008)"),
+  ;
+
+  companion object {
+    fun find(data: MutableMap<String, Any?>): String? =
+      (data["name"] as? String)?.let { rawName ->
+        val name = rawName.trim()
+        IOSPlayerErrorType.entries
+          .firstOrNull { type ->
+            type.matches.any { it.equals(name, true) }
+          }?.name
+      }
   }
 }

--- a/src/test/kotlin/ch/srgssr/pillarbox/monitoring/event/model/ErrorProcessorTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/monitoring/event/model/ErrorProcessorTest.kt
@@ -110,4 +110,52 @@ class ErrorProcessorTest(
       val dataNode = eventRequest.data as Map<*, *>
       dataNode["error_type"] shouldBe null
     }
+
+    should("classify iOS errors correctly based on the predefined names") {
+      // Given: an input with a predefined error message
+      val jsonInput =
+        """
+        {
+          "session_id": "12345",
+          "event_name": "ERROR",
+          "timestamp": 1630000000000,
+          "user_ip": "127.0.0.1",
+          "version": 1,
+          "data": {
+            "name": "CoreMediaErrorDomain(1)"
+          }
+        }
+        """.trimIndent()
+
+      // When: the event is deserialized
+      val eventRequest = objectMapper.readValue<EventRequest>(jsonInput)
+
+      // Then: The error should be classified correctly
+      val dataNode = eventRequest.data as Map<*, *>
+      dataNode["error_type"] shouldBe "PLAYBACK_MEDIA_SOURCE_ERROR"
+    }
+
+    should("not classify iOS errors is no name matches") {
+      // Given: an input with a predefined error message
+      val jsonInput =
+        """
+        {
+          "session_id": "12345",
+          "event_name": "ERROR",
+          "timestamp": 1630000000000,
+          "user_ip": "127.0.0.1",
+          "version": 1,
+          "data": {
+            "name": "CoreMediaErrorDomain(-1)"
+          }
+        }
+        """.trimIndent()
+
+      // When: the event is deserialized
+      val eventRequest = objectMapper.readValue<EventRequest>(jsonInput)
+
+      // Then: The error should be classified correctly
+      val dataNode = eventRequest.data as Map<*, *>
+      dataNode["error_type"] shouldBe "UNKNOWN_ERROR"
+    }
   })


### PR DESCRIPTION
## Description

Resolves #48 by introducing support for classifying iOS specific error types.

## Changes Made

- Added `IOSPlayerErrorType` enum to map known iOS error codes to standard error categories.
- Updated `ErrorProcessor` to support multi-platform error classification.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
