### PR TITLE
feat: classify 418 as connection error

### DIFF
--- a/src/test/kotlin/ch/srgssr/pillarbox/monitoring/event/model/ErrorProcessorTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/monitoring/event/model/ErrorProcessorTest.kt
@@ -207,4 +207,52 @@ class ErrorProcessorTest(
       val dataNode = eventRequest.data as Map<*, *>
       dataNode["error_type"] shouldBe "IL_ERROR"
     }
+
+    should("distinguish between CONNECTION_ERROR and IL_ERROR") {
+      // Given: an input with a predefined error message
+      val jsonInput =
+        """
+        {
+          "session_id": "12345",
+          "event_name": "ERROR",
+          "timestamp": 1630000000000,
+          "user_ip": "127.0.0.1",
+          "version": 1,
+          "data": {
+            "log": "ERROR: Received \"httpStatusCode\": 418, on il.srgssr.ch"
+          }
+        }
+        """.trimIndent()
+
+      // When: the event is deserialized
+      val eventRequest = objectMapper.readValue<EventRequest>(jsonInput)
+
+      // Then: The error should be classified correctly
+      val dataNode = eventRequest.data as Map<*, *>
+      dataNode["error_type"] shouldBe "CONNECTION_ERROR"
+    }
+
+    should("Classify IL_ERROR correctly") {
+      // Given: an input with a predefined error message
+      val jsonInput =
+        """
+        {
+          "session_id": "12345",
+          "event_name": "ERROR",
+          "timestamp": 1630000000000,
+          "user_ip": "127.0.0.1",
+          "version": 1,
+          "data": {
+            "log": "ERROR: Received 404 on il.srgssr.ch"
+          }
+        }
+        """.trimIndent()
+
+      // When: the event is deserialized
+      val eventRequest = objectMapper.readValue<EventRequest>(jsonInput)
+
+      // Then: The error should be classified correctly
+      val dataNode = eventRequest.data as Map<*, *>
+      dataNode["error_type"] shouldBe "IL_ERROR"
+    }
   })


### PR DESCRIPTION
## Description

Resolves #57 by classifying `418` reported errors as connection errors. Ensures that integration layer errors are still reported as such.

## Changes Made

- Introduced priority weights to the web player error resolution, to properly distinguish between `IL_ERROR` and `CONNECTION_ERROR` errors when the reported url for a connection error contains `il.srgssr.ch`.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
