### PR TITLE
feat: detect embed content

### DIFF
--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/model/EventRequestDataConverter.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/model/EventRequestDataConverter.kt
@@ -17,6 +17,7 @@ internal class EventRequestDataConverter : StdConverter<EventRequest, EventReque
     listOf(
       DeviceNameProcessor(),
       UserAgentProcessor(),
+      OriginProcessor(),
       ContentRestrictionProcessor(),
       ErrorProcessor(),
       ClampingNumberDataProcessor(),

--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/model/OriginProcessor.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/model/OriginProcessor.kt
@@ -1,0 +1,38 @@
+package ch.srgssr.pillarbox.monitoring.event.model
+
+/**
+ * A processor that determines whether the event originated from an embedded player.
+ */
+internal class OriginProcessor : DataProcessor {
+  companion object {
+    val pattern = Regex(".*/play/embed(?:[?]|/).*")
+  }
+
+  private fun isEmbeddedOrigin(origin: String): Boolean = pattern.matches(origin)
+
+  /**
+   * Process only on START events.
+   */
+  override fun shouldProcess(
+    eventName: String,
+    data: Map<String, Any?>,
+  ): Boolean = eventName == "START"
+
+  /**
+   * Processes the given data node to evaluate and mark embedded origins. The result
+   * is stored under the `embed` field.
+   *
+   * @param data The data node to process.
+   *
+   * @return The enriched data node with the embed classification.
+   */
+  @Suppress("UNCHECKED_CAST")
+  override fun process(data: MutableMap<String, Any?>): MutableMap<String, Any?> {
+    val mediaNode = data["media"] as? MutableMap<String, Any?>
+    val origin = (mediaNode?.get("origin") as? String) ?: return data
+
+    data["embed"] = isEmbeddedOrigin(origin)
+
+    return data
+  }
+}

--- a/src/main/resources/opensearch/core_events-template.json
+++ b/src/main/resources/opensearch/core_events-template.json
@@ -231,6 +231,9 @@
             "robot": {
               "type": "boolean"
             },
+            "embed": {
+              "type": "boolean"
+            },
             "screen": {
               "properties": {
                 "height": {

--- a/src/main/resources/opensearch/core_user_events-alias.json
+++ b/src/main/resources/opensearch/core_user_events-alias.json
@@ -7,7 +7,8 @@
         "filter": {
           "bool": {
             "must_not": [
-              { "term": { "session.robot": true } }
+              { "term": { "session.robot": true } },
+              { "term": { "session.embed": true } }
             ]
           }
         }

--- a/src/main/resources/opensearch/heartbeat_events-template.json
+++ b/src/main/resources/opensearch/heartbeat_events-template.json
@@ -209,6 +209,9 @@
             "robot": {
               "type": "boolean"
             },
+            "embed": {
+              "type": "boolean"
+            },
             "screen": {
               "properties": {
                 "height": {

--- a/src/main/resources/opensearch/user_events-alias.json
+++ b/src/main/resources/opensearch/user_events-alias.json
@@ -7,7 +7,8 @@
         "filter": {
           "bool": {
             "must_not": [
-              { "term": { "session.robot": true } }
+              { "term": { "session.robot": true } },
+              { "term": { "session.embed": true } }
             ]
           }
         }
@@ -20,7 +21,8 @@
         "filter": {
           "bool": {
             "must_not": [
-              { "term": { "session.robot": true } }
+              { "term": { "session.robot": true } },
+              { "term": { "session.embed": true } }
             ]
           }
         }

--- a/src/test/kotlin/ch/srgssr/pillarbox/monitoring/event/model/OriginProcessorTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/monitoring/event/model/OriginProcessorTest.kt
@@ -1,0 +1,92 @@
+package ch.srgssr.pillarbox.monitoring.event.model
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+@SpringBootTest
+@ActiveProfiles("test")
+class OriginProcessorTest(
+  private val objectMapper: ObjectMapper,
+) : ShouldSpec({
+    should("detect an embedded event from the media origin") {
+      // Given: an input with a user agent
+      val jsonInput =
+        """
+        {
+          "session_id": "12345",
+          "event_name": "START",
+          "timestamp": 1630000000000,
+          "user_ip": "127.0.0.1",
+          "version": 1,
+          "data": {
+            "media": {
+              "origin": "https://www.rts.ch/play/embed?urn=urn:rts:video:1234"
+            }
+          }
+        }
+        """.trimIndent()
+
+      // When: the event is deserialized
+      val eventRequest = objectMapper.readValue<EventRequest>(jsonInput)
+
+      // Then: The user agent data should have been resolved
+      val dataNode = eventRequest.data as Map<*, *>
+      dataNode["embed"] shouldBe true
+    }
+
+    should("detect not flag an event as embedded if it comes from a non embedded origin") {
+      // Given: an input with a user agent
+      val jsonInput =
+        """
+        {
+          "session_id": "12345",
+          "event_name": "START",
+          "timestamp": 1630000000000,
+          "user_ip": "127.0.0.1",
+          "version": 1,
+          "data": {
+            "media": {
+              "origin": "https://www.rts.ch/live?rts1"
+            }
+          }
+        }
+        """.trimIndent()
+
+      // When: the event is deserialized
+      val eventRequest = objectMapper.readValue<EventRequest>(jsonInput)
+
+      // Then: The user agent data should have been resolved
+      val dataNode = eventRequest.data as Map<*, *>
+      dataNode["embed"] shouldBe false
+    }
+
+    should("detect not add the flag if the media origin is no present") {
+      // Given: an input with a user agent
+      val jsonInput =
+        """
+        {
+          "session_id": "12345",
+          "event_name": "START",
+          "timestamp": 1630000000000,
+          "user_ip": "127.0.0.1",
+          "version": 1,
+          "data": {
+            "media": {
+              "id": "urn:rts:video:1234"
+            }
+          }
+        }
+        """.trimIndent()
+
+      // When: the event is deserialized
+      val eventRequest = objectMapper.readValue<EventRequest>(jsonInput)
+
+      // Then: The user agent data should have been resolved
+      val dataNode = eventRequest.data as Map<*, *>
+      dataNode["embed"] shouldBe null
+    }
+  })


### PR DESCRIPTION
## Description

Resolves #56 by detecting embed content based on the `media.origin` field of the `START` event.

## Changes Made

* Added an `OriginProcessor` to detect embed content.
* Added an `embed` flag to the session data that determines whether the content is embedded.
* Modified the existing aliases to filter based on this flag.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
