### PR TITLE
fix: optimize `eager_global_ordinals` usage in index templates

### DIFF
--- a/src/main/resources/opensearch/core_events-template.json
+++ b/src/main/resources/opensearch/core_events-template.json
@@ -15,12 +15,12 @@
       "properties": {
         "session_id": {
           "type": "keyword",
-          "ignore_above": 256,
-          "eager_global_ordinals": true
+          "ignore_above": 256
         },
         "event_name": {
           "type": "keyword",
-          "ignore_above": 256
+          "ignore_above": 256,
+          "eager_global_ordinals": true
         },
         "user_ip": {
           "type": "keyword",
@@ -62,11 +62,13 @@
             },
             "error_type": {
               "type": "keyword",
-              "ignore_above": 256
+              "ignore_above": 256,
+              "eager_global_ordinals": true
             },
             "block_reason": {
               "type": "keyword",
-              "ignore_above": 256
+              "ignore_above": 256,
+              "eager_global_ordinals": true
             },
             "business_error": {
               "type": "boolean"
@@ -125,7 +127,8 @@
               "properties": {
                 "name": {
                   "type": "keyword",
-                  "ignore_above": 256
+                  "ignore_above": 256,
+                  "eager_global_ordinals": true
                 },
                 "user_agent": {
                   "type": "keyword",
@@ -149,7 +152,8 @@
                 },
                 "type": {
                   "type": "keyword",
-                  "ignore_above": 256
+                  "ignore_above": 256,
+                  "eager_global_ordinals": true
                 }
               }
             },
@@ -161,8 +165,7 @@
                 },
                 "id": {
                   "type": "keyword",
-                  "ignore_above": 256,
-                  "eager_global_ordinals": true
+                  "ignore_above": 256
                 },
                 "metadata_url": {
                   "type": "keyword",
@@ -178,7 +181,8 @@
               "properties": {
                 "name": {
                   "type": "keyword",
-                  "ignore_above": 256
+                  "ignore_above": 256,
+                  "eager_global_ordinals": true
                 },
                 "version": {
                   "type": "keyword",
@@ -190,15 +194,18 @@
               "properties": {
                 "name": {
                   "type": "keyword",
-                  "ignore_above": 256
+                  "ignore_above": 256,
+                  "eager_global_ordinals": true
                 },
                 "platform": {
                   "type": "keyword",
-                  "ignore_above": 256
+                  "ignore_above": 256,
+                  "eager_global_ordinals": true
                 },
                 "version": {
                   "type": "keyword",
-                  "ignore_above": 256
+                  "ignore_above": 256,
+                  "eager_global_ordinals": true
                 }
               }
             },

--- a/src/main/resources/opensearch/heartbeat_events-template.json
+++ b/src/main/resources/opensearch/heartbeat_events-template.json
@@ -15,12 +15,12 @@
       "properties": {
         "session_id": {
           "type": "keyword",
-          "ignore_above": 256,
-          "eager_global_ordinals": true
+          "ignore_above": 256
         },
         "event_name": {
           "type": "keyword",
-          "ignore_above": 256
+          "ignore_above": 256,
+          "eager_global_ordinals": true
         },
         "user_ip": {
           "type": "keyword",
@@ -103,7 +103,8 @@
               "properties": {
                 "name": {
                   "type": "keyword",
-                  "ignore_above": 256
+                  "ignore_above": 256,
+                  "eager_global_ordinals": true
                 },
                 "user_agent": {
                   "type": "keyword",
@@ -127,7 +128,8 @@
                 },
                 "type": {
                   "type": "keyword",
-                  "ignore_above": 256
+                  "ignore_above": 256,
+                  "eager_global_ordinals": true
                 }
               }
             },
@@ -139,8 +141,7 @@
                 },
                 "id": {
                   "type": "keyword",
-                  "ignore_above": 256,
-                  "eager_global_ordinals": true
+                  "ignore_above": 256
                 },
                 "metadata_url": {
                   "type": "keyword",
@@ -156,7 +157,8 @@
               "properties": {
                 "name": {
                   "type": "keyword",
-                  "ignore_above": 256
+                  "ignore_above": 256,
+                  "eager_global_ordinals": true
                 },
                 "version": {
                   "type": "keyword",
@@ -168,15 +170,18 @@
               "properties": {
                 "name": {
                   "type": "keyword",
-                  "ignore_above": 256
+                  "ignore_above": 256,
+                  "eager_global_ordinals": true
                 },
                 "platform": {
                   "type": "keyword",
-                  "ignore_above": 256
+                  "ignore_above": 256,
+                  "eager_global_ordinals": true
                 },
                 "version": {
                   "type": "keyword",
-                  "ignore_above": 256
+                  "ignore_above": 256,
+                  "eager_global_ordinals": true
                 }
               }
             },


### PR DESCRIPTION
## Description

Adjusted the mapping for `core_events` and `heartbeat_events` templates to improve query performance and reduce memory pressure caused by unnecessary eager global ordinals.

This change ensures that only relevant fields benefit from eager loading, while high-cardinality identifiers continue to use lazy ordinals.


**See https://docs.opensearch.org/latest/field-types/mapping-parameters/eager_global_ordinals/**
> Global ordinals represent a mapping from term values to integer identifiers and are used internally to quickly execute aggregations and sort operations. By loading them “eagerly,” the system reduces query latency at the cost of additional upfront processing during indexing.


## Changes Made

- Removed `eager_global_ordinals` from high-cardinality fields such as `session_id` and `media.id` to avoid excessive heap usage and slow indexing.
- Enabled `eager_global_ordinals` on low/medium-cardinality fields that are frequently aggregated in dashboards, e.g: `event_name`, `error_type`, `block_reason`, `browser.name`...

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
