### PR TITLE
feat: add `short_origin` field

### DIFF
--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/model/OriginProcessor.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/model/OriginProcessor.kt
@@ -1,14 +1,30 @@
 package ch.srgssr.pillarbox.monitoring.event.model
 
+import ch.srgssr.pillarbox.monitoring.event.model.OriginProcessor.Companion.pattern
+import ch.srgssr.pillarbox.monitoring.log.logger
+import ch.srgssr.pillarbox.monitoring.log.warn
+import java.net.MalformedURLException
+import java.net.URI
+import java.net.URISyntaxException
+
 /**
- * A processor that determines whether the event originated from an embedded player.
+ * A processor that enriches media event data with origin-related metadata:
+ *
+ * - Determines whether the event originated from an embedded player.
+ * - Provides a shortened representation of the media origin (host + first path segment).
  */
 internal class OriginProcessor : DataProcessor {
   companion object {
-    val pattern = Regex(".*/play/embed(?:[?]|/).*")
-  }
+    /**
+     * The pattern to detect embedded origins
+     */
+    private val pattern = Regex(".*/play/embed(?:[?]|/).*")
 
-  private fun isEmbeddedOrigin(origin: String): Boolean = pattern.matches(origin)
+    /**
+     * Logger instance for logging within this processor.
+     */
+    private val logger = logger()
+  }
 
   /**
    * Process only on START events.
@@ -19,20 +35,46 @@ internal class OriginProcessor : DataProcessor {
   ): Boolean = eventName == "START"
 
   /**
-   * Processes the given data node to evaluate and mark embedded origins. The result
-   * is stored under the `embed` field.
+   * Processes the given data node:
+   * - Adds a shortened origin string under the key `short_origin`
+   *   if the `origin` field contains a valid absolute HTTP/HTTPS URL.
+   * - Flags the event with `embed = true` if the origin matches [pattern].
    *
-   * @param data The data node to process.
-   *
-   * @return The enriched data node with the embed classification.
+   * @param data The event data to process (must contain a `media` node).
+   * @return The enriched data map.
    */
   @Suppress("UNCHECKED_CAST")
   override fun process(data: MutableMap<String, Any?>): MutableMap<String, Any?> {
     val mediaNode = data["media"] as? MutableMap<String, Any?>
     val origin = (mediaNode?.get("origin") as? String) ?: return data
 
+    shortenOrigin(origin)?.let { mediaNode["short_origin"] = it }
     data["embed"] = isEmbeddedOrigin(origin)
 
     return data
   }
+
+  private fun isEmbeddedOrigin(origin: String): Boolean = pattern.matches(origin)
+
+  private fun shortenOrigin(origin: String): String? =
+    runCatching {
+      URI(origin)
+        .toURL()
+        .let { url ->
+          listOf(
+            url.host,
+            url.path.split('/').firstOrNull { it.isNotBlank() },
+          )
+        }.filterNotNull()
+        .joinToString("/")
+    }.onFailure { e ->
+      when (e) {
+        is URISyntaxException,
+        is MalformedURLException,
+        is IllegalArgumentException,
+        -> logger.warn(e) { "Not an absolute URL: $origin" }
+
+        else -> throw e
+      }
+    }.getOrNull()
 }

--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/log/LoggingExtensions.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/log/LoggingExtensions.kt
@@ -13,34 +13,54 @@ inline fun <reified T> T.logger(): Logger = LoggerFactory.getLogger(T::class.jav
 /**
  * Logs a trace message if the trace level is enabled for the logger.
  *
+ * @param e An optional [Throwable] to be logged alongside the message.
  * @param lazyMessage A lambda function that generates the log message only if trace logging is enabled.
  */
-inline fun Logger.trace(lazyMessage: () -> String) = isTraceEnabled.takeIf { it }?.let { trace(lazyMessage()) }
+inline fun Logger.trace(
+  e: Throwable? = null,
+  lazyMessage: () -> String,
+) = isTraceEnabled.takeIf { it }?.let { trace(lazyMessage(), e) }
 
 /**
  * Logs a debug message if the debug level is enabled for the logger.
  *
+ * @param e An optional [Throwable] to be logged alongside the message.
  * @param lazyMessage A lambda function that generates the log message only if debug logging is enabled.
  */
-inline fun Logger.debug(lazyMessage: () -> String) = isDebugEnabled.takeIf { it }?.let { debug(lazyMessage()) }
+inline fun Logger.debug(
+  e: Throwable? = null,
+  lazyMessage: () -> String,
+) = isDebugEnabled.takeIf { it }?.let { debug(lazyMessage(), e) }
 
 /**
  * Logs an info message if the info level is enabled for the logger.
  *
+ * @param e An optional [Throwable] to be logged alongside the message.
  * @param lazyMessage A lambda function that generates the log message only if info logging is enabled.
  */
-inline fun Logger.info(lazyMessage: () -> String) = isInfoEnabled.takeIf { it }?.let { info(lazyMessage()) }
+inline fun Logger.info(
+  e: Throwable? = null,
+  lazyMessage: () -> String,
+) = isInfoEnabled.takeIf { it }?.let { info(lazyMessage(), e) }
 
 /**
  * Logs a warning message if the warn level is enabled for the logger.
  *
+ * @param e An optional [Throwable] to be logged alongside the message.
  * @param lazyMessage A lambda function that generates the log message only if warn logging is enabled.
  */
-inline fun Logger.warn(lazyMessage: () -> String) = isWarnEnabled.takeIf { it }?.let { warn(lazyMessage()) }
+inline fun Logger.warn(
+  e: Throwable? = null,
+  lazyMessage: () -> String,
+) = isWarnEnabled.takeIf { it }?.let { warn(lazyMessage(), e) }
 
 /**
  * Logs an error message if the error level is enabled for the logger.
  *
+ * @param e An optional [Throwable] to be logged alongside the message.
  * @param lazyMessage A lambda function that generates the log message only if error logging is enabled.
  */
-inline fun Logger.error(lazyMessage: () -> String) = isErrorEnabled.takeIf { it }?.let { error(lazyMessage()) }
+inline fun Logger.error(
+  e: Throwable? = null,
+  lazyMessage: () -> String,
+) = isErrorEnabled.takeIf { it }?.let { error(lazyMessage(), e) }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -2,3 +2,7 @@ pillarbox.monitoring.dispatch:
   buffer-capacity: 30_000
   cache-size: 200_000
   save-chunk-size: 6_000
+
+logging:
+  level:
+    ch.srgssr.pillarbox.monitoring.event.model: ERROR

--- a/src/main/resources/opensearch/core_events-template.json
+++ b/src/main/resources/opensearch/core_events-template.json
@@ -174,6 +174,10 @@
                 "origin": {
                   "type": "keyword",
                   "ignore_above": 256
+                },
+                "short_origin": {
+                  "type": "keyword",
+                  "ignore_above": 256
                 }
               }
             },

--- a/src/main/resources/opensearch/heartbeat_events-template.json
+++ b/src/main/resources/opensearch/heartbeat_events-template.json
@@ -150,6 +150,10 @@
                 "origin": {
                   "type": "keyword",
                   "ignore_above": 256
+                },
+                "short_origin": {
+                  "type": "keyword",
+                  "ignore_above": 256
                 }
               }
             },


### PR DESCRIPTION
## Description

Enriches the session data with a shortened version of the origin URL, making it easier to query and aggregate data based on origin. The `short_origin` field is calculated as the host the first path segment.

## Changes Made

- Updated index templates to include the `short_origin` field.
- Extended logger extension to accept an optional exception parameter.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
