### PR TITLE
feat: enrich session data with business unit, type and swisstxt flag

### DIFF
--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/model/EventRequestDataConverter.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/model/EventRequestDataConverter.kt
@@ -18,6 +18,7 @@ internal class EventRequestDataConverter : StdConverter<EventRequest, EventReque
       DeviceNameProcessor(),
       UserAgentProcessor(),
       OriginProcessor(),
+      MediaIdProcessor(),
       ContentRestrictionProcessor(),
       ErrorProcessor(),
       ClampingNumberDataProcessor(),

--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/model/MediaIdProcessor.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/event/model/MediaIdProcessor.kt
@@ -1,0 +1,92 @@
+package ch.srgssr.pillarbox.monitoring.event.model
+
+/**
+ * Enriches media event data using the media id:
+ *
+ * - Resolves the business unit.
+ * - Resolves the media type.
+ * - Flags whether the media is provided by SwissTXT.
+ */
+internal class MediaIdProcessor : DataProcessor {
+  companion object {
+    val swisstxtPattern = Regex("^urn:(?:.*:)?swisstxt:.*$")
+  }
+
+  /**
+   * Process only on START events.
+   */
+  override fun shouldProcess(
+    eventName: String,
+    data: Map<String, Any?>,
+  ): Boolean = eventName == "START"
+
+  /**
+   * Processes the given data node:
+   * - Adds the resolved business unit from the media id.
+   * - Add the resolved media type from the media id.
+   * - Flags the media as `swisstxt` if the media id is identified as a swisstxt provided stream.
+   *
+   * @param data The event data to process (should contain a `media` node).
+   *
+   * @return The enriched data map.
+   */
+  @Suppress("UNCHECKED_CAST")
+  override fun process(data: MutableMap<String, Any?>): MutableMap<String, Any?> {
+    val mediaNode = data["media"] as? MutableMap<String, Any?>
+    val id = mediaNode?.get("id") as? String ?: return data
+
+    mediaNode["bu"] = BusinessUnit.find(id)
+    mediaNode["type"] = MediaType.find(id)
+    mediaNode["swisstxt"] = swisstxtPattern.matches(id)
+
+    return data
+  }
+}
+
+/**
+ * Enum representing different business units.
+ */
+internal enum class BusinessUnit(
+  pattern: String,
+) {
+  SRF("^urn:(?:.*:)?srf:.*$"),
+  RTS("^urn:(?:.*:)?rts:.*$"),
+  RSI("^urn:(?:.*:)?rsi:.*$"),
+  RTR("^urn:(?:.*:)?rtr:.*$"),
+  PLAYSUISSE("^urn:(?:.*:)?rio:.*$"),
+  SWI("^urn:(?:.*:)?swi:.*$"),
+  ;
+
+  val pattern = Regex(pattern)
+
+  companion object {
+    fun find(id: String): String? =
+      BusinessUnit.entries
+        .find {
+          it.pattern.matches(id)
+        }?.name
+        ?.lowercase()
+  }
+}
+
+/**
+ * Enum representing different media types.
+ */
+internal enum class MediaType(
+  pattern: String,
+) {
+  VIDEO("^urn:.*:video:.*$"),
+  AUDIO("^urn:.*:audio:.*$"),
+  ;
+
+  val pattern = Regex(pattern)
+
+  companion object {
+    fun find(id: String): String? =
+      MediaType.entries
+        .find {
+          it.pattern.matches(id)
+        }?.name
+        ?.lowercase()
+  }
+}

--- a/src/main/resources/opensearch/core_events-template.json
+++ b/src/main/resources/opensearch/core_events-template.json
@@ -178,6 +178,19 @@
                 "short_origin": {
                   "type": "keyword",
                   "ignore_above": 256
+                },
+                "bu": {
+                  "type": "keyword",
+                  "ignore_above": 256,
+                  "eager_global_ordinals": true
+                },
+                "type": {
+                  "type": "keyword",
+                  "ignore_above": 256,
+                  "eager_global_ordinals": true
+                },
+                "swisstxt": {
+                  "type": "boolean"
                 }
               }
             },

--- a/src/main/resources/opensearch/heartbeat_events-template.json
+++ b/src/main/resources/opensearch/heartbeat_events-template.json
@@ -154,6 +154,19 @@
                 "short_origin": {
                   "type": "keyword",
                   "ignore_above": 256
+                },
+                "bu": {
+                  "type": "keyword",
+                  "ignore_above": 256,
+                  "eager_global_ordinals": true
+                },
+                "type": {
+                  "type": "keyword",
+                  "ignore_above": 256,
+                  "eager_global_ordinals": true
+                },
+                "swisstxt": {
+                  "type": "boolean"
                 }
               }
             },

--- a/src/test/kotlin/ch/srgssr/pillarbox/monitoring/event/model/MediaIdProcessorTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/monitoring/event/model/MediaIdProcessorTest.kt
@@ -1,0 +1,67 @@
+package ch.srgssr.pillarbox.monitoring.event.model
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+@SpringBootTest
+@ActiveProfiles("test")
+class MediaIdProcessorTest(
+  private val objectMapper: ObjectMapper,
+) : ShouldSpec({
+    @Suppress("DestructuringDeclarationWithTooManyEntries")
+    listOf(
+      testCase("urn:rts:video:3608517", bu = "rts", type = "video"),
+      testCase("urn:rts:scheduled_livestream:video:c2649494-001a-4980-af44-6e044eab1dd5", bu = "rts", type = "video"),
+      testCase("urn:srf:audio:dd0fa1ba-4ff6-4e1a-ab74-d7e49057d96f", bu = "srf", type = "audio"),
+      testCase("urn:swisstxt:video:srf:1818152", bu = "srf", type = "video", swisstxt = true),
+      testCase("urn:rio:video:3387013:main", bu = "playsuisse", type = "video"),
+      testCase("urn:swisstxt:video:rsi:1832855", bu = "rsi", type = "video", swisstxt = true),
+      testCase("urn:foo:bar:1234"),
+      testCase(""),
+    ).forEach { (id, bu, type, swisstxt) ->
+      should("resolve $id to bu=$bu, type=$type, swisstxt=$swisstxt") {
+        val jsonInput =
+          """
+          {
+            "session_id": "12345",
+            "event_name": "START",
+            "timestamp": 1630000000000,
+            "user_ip": "127.0.0.1",
+            "version": 1,
+            "data": {
+              "media": {
+                "id": "$id"
+              }
+            }
+          }
+          """.trimIndent()
+
+        // When: the event is deserialized
+        val eventRequest = objectMapper.readValue<EventRequest>(jsonInput)
+        val dataNode = eventRequest.data as Map<*, *>
+        val mediaNode = dataNode["media"] as Map<*, *>
+
+        mediaNode["bu"] shouldBe bu
+        mediaNode["type"] shouldBe type
+        mediaNode["swisstxt"] shouldBe swisstxt
+      }
+    }
+  })
+
+data class MediaIdExpectation(
+  val id: String,
+  val bu: String?,
+  val type: String?,
+  val swisstxt: Boolean,
+)
+
+fun testCase(
+  id: String,
+  bu: String? = null,
+  type: String? = null,
+  swisstxt: Boolean = false,
+) = MediaIdExpectation(id, bu, type, swisstxt)


### PR DESCRIPTION
## Description

Session data is now enriched during preprocessing with:

- Resolved business unit: srf, rts, rsi, rtr, playsuisse or swi.
- Resolved media type: video or audio.
- A flag indicating whether the stream is provided by swisstxt

This changes removes the need for complex wildcard queries and makes filters in
grafana dashboards easier to build and more efficient.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
