### PR TITLE
fix(error-processor): handle kCFErrorDomainCFNetwork iOS connection errors

### DIFF
--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/opensearch/model/ErrorProcessor.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/opensearch/model/ErrorProcessor.kt
@@ -142,12 +142,12 @@ internal enum class IOSPlayerErrorType(
   /**
    * A network error occurred during playback.
    */
-  PLAYBACK_NETWORK_ERROR("NSURLErrorDomain\\(.*?\\)"),
+  PLAYBACK_NETWORK_ERROR("NSURLErrorDomain\\(.*?\\)", "kCFErrorDomainCFNetwork\\(.*?\\)"),
 
   /**
    * The user experienced a connection problem to the remote API or the media resource.
    */
-  CONECTION_ERROR("NSURLErrorDomain\\(-1009\\)", priority = 10),
+  CONNECTION_ERROR("NSURLErrorDomain\\(-100(5|9)\\)", "kCFErrorDomainCFNetwork\\(-100(5|9)\\)", priority = 10),
   ;
 
   private val matches = matches.map { Regex(it, RegexOption.IGNORE_CASE) }

--- a/src/test/kotlin/ch/srgssr/pillarbox/monitoring/opensearch/model/ErrorProcessorTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/monitoring/opensearch/model/ErrorProcessorTest.kt
@@ -296,6 +296,37 @@ class ErrorProcessorTest :
       dataNode["error_type"] shouldBe "CONNECTION_ERROR"
     }
 
+    listOf(
+      "kCFErrorDomainCFNetwork(-1200)" to "PLAYBACK_NETWORK_ERROR",
+      "kCFErrorDomainCFNetwork(-1009)" to "CONNECTION_ERROR",
+      "kCFErrorDomainCFNetwork(-1005)" to "CONNECTION_ERROR",
+      "NSURLErrorDomain(-1005)" to "CONNECTION_ERROR",
+    ).forEach { (name, expectedErrorType) ->
+      should("classify iOS $name errors as $expectedErrorType") {
+        val jsonInput =
+          """
+          {
+            "session_id": "12345",
+            "event_name": "ERROR",
+            "timestamp": 1630000000000,
+            "user_ip": "127.0.0.1",
+            "version": 1,
+            "data": {
+              "name": "$name"
+            }
+          }
+          """.trimIndent()
+        val eventRequest =
+          jsonMapper.readValue(
+            jsonInput,
+            EventRequest::class.java,
+          )
+
+        val dataNode = eventRequest.data as Map<*, *>
+        dataNode["error_type"] shouldBe expectedErrorType
+      }
+    }
+
     should("Classify IL_ERROR correctly") {
       // Given: an input with a predefined error message
       val jsonInput =


### PR DESCRIPTION
## Changes Made

- Extend `PLAYBACK_NETWORK_ERROR` and `CONNECTION_ERROR` patterns to match `kCFErrorDomainCFNetwork` in addition to `NSURLErrorDomain`.
- Fix typo in `CONNECTION_ERROR` enum name and add error code -1005 (connection lost) to the connection error pattern.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
