### PR TITLE
fix: improve geoblocking message detection

### DIFF
--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/opensearch/model/BlockReasonProcessor.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/opensearch/model/BlockReasonProcessor.kt
@@ -86,6 +86,7 @@ internal enum class ContentRestriction(
       "This content is not available outside Switzerland",
       "Dieser Inhalt ist ausserhalb der Schweiz nicht verfügbar",
       "La RTS ne dispose pas des droits de diffusion en dehors de la Suisse",
+      "Ce contenu n'est pas disponible hors de Suisse",
       "Questo media non è disponibile fuori dalla Svizzera",
       "Questo contenuto non è disponibile fuori dalla Svizzera",
       "Quest cuntegn n'è betg disponibel ordaifer la Svizra",


### PR DESCRIPTION
## Description

This PR improves error classification by taking into account the French geoblocking error message.

### Remark

Romansh translation alignment should be made. Until then the corresponding message was not added to the processor rules.

## Changes Made

Self-explanatory.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
