### PR TITLE
feat(health): add activity tracking and ALB health check endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Alternatively, you can build and run the application using Docker:
               pillarbox-monitoring-transfer
    ```
 
+   Port `8081` exposes the health check endpoint at `/health`. It returns `200 OK` while events
+   are flowing and `503 Service Unavailable` after a period of inactivity, making it suitable for
+   use as an ALB health check target.
+
 ## Documentation
 
 This project is a Kotlin-based application designed to connect to a Server-Sent Events (SSE)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,8 @@ dependencies {
   implementation(libs.kotlin.coroutines.core.jvm)
   implementation(libs.ktor.client.cio)
   implementation(libs.ktor.client.core)
+  implementation(libs.ktor.server.cio)
+  implementation(libs.ktor.server.core)
   implementation(libs.logback.classic)
   implementation(libs.yauaa)
   runtimeOnly(libs.hoplite.yaml)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,8 @@ koin-logger = { module = "io.insert-koin:koin-logger-slf4j", version.ref = "koin
 kotlin-coroutines-core-jvm = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm", version.ref = "kotlin-coroutines" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-server-cio = { module = "io.ktor:ktor-server-cio", version.ref = "ktor" }
+ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
 log4j-to-slf4j = { module = "org.apache.logging.log4j:log4j-to-slf4j", version.ref = "log4j" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 yauaa = { module = "nl.basjes.parse.useragent:yauaa", version.ref = "yauaa" }

--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/DataTransferApplicationRunner.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/DataTransferApplicationRunner.kt
@@ -2,6 +2,7 @@ package ch.srgssr.pillarbox.monitoring
 
 import ch.srgssr.pillarbox.monitoring.benchmark.BenchmarkScheduledLogger
 import ch.srgssr.pillarbox.monitoring.dispatcher.EventDispatcherClient
+import ch.srgssr.pillarbox.monitoring.health.HealthCheckServer
 import ch.srgssr.pillarbox.monitoring.log.error
 import ch.srgssr.pillarbox.monitoring.log.logger
 import ch.srgssr.pillarbox.monitoring.opensearch.setup.OpenSearchSetupService
@@ -14,24 +15,26 @@ import ch.srgssr.pillarbox.monitoring.opensearch.setup.OpenSearchSetupService
  *
  * @property openSearchSetupService Service responsible for initializing and validating the OpenSearch setup.
  * @property eventDispatcherClient The client responsible for establishing a connection to the event dispatcher.
- * during either OpenSearch setup or SSE connection.
+ * @property healthCheckServer The HTTP server exposing the `/health` endpoint for ALB health checks.
  */
 class DataTransferApplicationRunner(
   private val openSearchSetupService: OpenSearchSetupService,
   private val eventDispatcherClient: EventDispatcherClient,
+  private val healthCheckServer: HealthCheckServer,
 ) {
   private companion object {
     val logger = logger()
   }
 
   /**
-   * Executes the OpenSearch setup task when the application starts.
+   * Starts the health check server, runs the OpenSearch setup, then starts the SSE client.
    *
-   * Upon successful setup, it initiates the [EventDispatcherClient]. If the setup fails,
-   * an error is logged and the application is terminated.
+   * The health check server starts first so the ALB can begin probing immediately during startup.
    */
   @Suppress("TooGenericExceptionCaught")
   suspend fun run() {
+    healthCheckServer.start()
+
     openSearchSetupService.start()
 
     val benchmarkJob = BenchmarkScheduledLogger.start()

--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/DataTransferModule.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/DataTransferModule.kt
@@ -2,6 +2,7 @@ package ch.srgssr.pillarbox.monitoring
 
 import ch.srgssr.pillarbox.monitoring.config.configModule
 import ch.srgssr.pillarbox.monitoring.dispatcher.eventDispatcherModule
+import ch.srgssr.pillarbox.monitoring.health.healthCheckModule
 import ch.srgssr.pillarbox.monitoring.io.jsonModule
 import ch.srgssr.pillarbox.monitoring.opensearch.openSearchModule
 import org.koin.dsl.module
@@ -26,7 +27,8 @@ fun dataTransferModule(vararg profiles: String) =
       jsonModule(),
       openSearchModule(),
       eventDispatcherModule(),
+      healthCheckModule(),
     )
 
-    single { DataTransferApplicationRunner(get(), get()) }
+    single { DataTransferApplicationRunner(get(), get(), get()) }
   }

--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/benchmark/BenchmarkScheduledLogger.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/benchmark/BenchmarkScheduledLogger.kt
@@ -2,29 +2,47 @@ package ch.srgssr.pillarbox.monitoring.benchmark
 
 import ch.srgssr.pillarbox.monitoring.log.debug
 import ch.srgssr.pillarbox.monitoring.log.logger
+import ch.srgssr.pillarbox.monitoring.log.warn
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlin.coroutines.CoroutineContext
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
 
 /**
- * A scheduled logger that periodically logs the average execution times
- * and stats regarding the number of processed events.
+ * A scheduled logger that periodically logs benchmark averages and stats,
+ * and warns when no events have been processed within the inactivity threshold.
  */
 object BenchmarkScheduledLogger {
   private val logger = logger()
 
   /**
-   * The scheduled logging function, executes every minute.
+   * Starts the scheduled logging coroutine, executing every minute.
+   *
+   * @param inactivityThreshold Duration of silence after which the application is considered inactive.
+   * @param context The coroutine context to run the scheduler in.
    */
-  fun start(context: CoroutineContext = Dispatchers.Default) =
-    CoroutineScope(context).launch {
-      while (isActive) {
-        logger.debug { "Benchmark averages: ${TimeTracker.averages}" }
-        logger.debug { "Latest stats per minute: ${StatsTracker.getAndResetAll()}" }
-        delay(60_000L)
+  fun start(
+    inactivityThreshold: Duration = 5.minutes,
+    context: CoroutineContext = Dispatchers.Default,
+  ) = CoroutineScope(context).launch {
+    while (isActive) {
+      val active = StatsTracker.isActive(inactivityThreshold)
+      val lastSeen = StatsTracker.lastSeenAt
+
+      logger.debug { "Benchmark averages: ${TimeTracker.averages}" }
+      logger.debug { "Latest stats per minute: ${StatsTracker.getAndResetAll()}" }
+
+      if (!active) {
+        logger.warn {
+          "No events processed within the last $inactivityThreshold. Last activity: ${lastSeen ?: "never"}"
+        }
       }
+
+      delay(60_000L)
     }
+  }
 }

--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/benchmark/BenchmarkScheduledLogger.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/benchmark/BenchmarkScheduledLogger.kt
@@ -1,6 +1,6 @@
 package ch.srgssr.pillarbox.monitoring.benchmark
 
-import ch.srgssr.pillarbox.monitoring.log.info
+import ch.srgssr.pillarbox.monitoring.log.debug
 import ch.srgssr.pillarbox.monitoring.log.logger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -22,8 +22,8 @@ object BenchmarkScheduledLogger {
   fun start(context: CoroutineContext = Dispatchers.Default) =
     CoroutineScope(context).launch {
       while (isActive) {
-        logger.info { "Benchmark averages: ${TimeTracker.averages}" }
-        logger.info { "Latest stats per minute: ${StatsTracker.getAndResetAll()}" }
+        logger.debug { "Benchmark averages: ${TimeTracker.averages}" }
+        logger.debug { "Latest stats per minute: ${StatsTracker.getAndResetAll()}" }
         delay(60_000L)
       }
     }

--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/benchmark/StatsTracker.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/benchmark/StatsTracker.kt
@@ -2,15 +2,23 @@ package ch.srgssr.pillarbox.monitoring.benchmark
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Instant
 
 /**
  * Utility object for tracking and aggregating statistics.
  *
  * This class uses a [ConcurrentHashMap] to store statistics counters identified by unique keys.
  * It provides methods to increment, retrieve, and reset these counters.
+ *
+ * Additionally, it tracks the last time any counter was incremented, which can be used
+ * to determine whether the application is actively processing events.
  */
 object StatsTracker {
   private val stats = ConcurrentHashMap<String, AtomicLong>()
+  private val lastActivityAt = AtomicReference(Clock.System.now())
 
   /**
    * Increments the count for a specific key by the specified delta.
@@ -24,6 +32,7 @@ object StatsTracker {
     delta: Long = 1,
   ) {
     stats.computeIfAbsent(key) { AtomicLong(0) }.addAndGet(delta)
+    lastActivityAt.set(Clock.System.now())
   }
 
   /**
@@ -53,4 +62,18 @@ object StatsTracker {
    * @return A map containing the keys and their corresponding counts before reset.
    */
   fun getAndResetAll(): Map<String, Long> = stats.mapValues { it.value.getAndSet(0) }
+
+  /**
+   * The timestamp of the last recorded activity, or `null` if no activity has been recorded yet.
+   */
+  val lastSeenAt: Instant?
+    get() = lastActivityAt.get()
+
+  /**
+   * Returns `true` if activity was recorded within the given [threshold].
+   *
+   * @param threshold The maximum duration of silence before the application is considered inactive.
+   */
+  fun isActive(threshold: Duration): Boolean =
+    lastActivityAt.get()?.let { Clock.System.now() - it < threshold } ?: false
 }

--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/config/ConfigLoader.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/config/ConfigLoader.kt
@@ -1,6 +1,7 @@
 package ch.srgssr.pillarbox.monitoring.config
 
 import ch.srgssr.pillarbox.monitoring.dispatcher.EventDispatcherClientConfig
+import ch.srgssr.pillarbox.monitoring.health.HealthCheckConfig
 import ch.srgssr.pillarbox.monitoring.log.info
 import ch.srgssr.pillarbox.monitoring.log.logger
 import ch.srgssr.pillarbox.monitoring.opensearch.OpenSearchConfig
@@ -58,4 +59,5 @@ object ConfigLoader {
 data class AppConfig(
   val openSearch: OpenSearchConfig = OpenSearchConfig(),
   val dispatcherClient: EventDispatcherClientConfig = EventDispatcherClientConfig(),
+  val healthCheck: HealthCheckConfig = HealthCheckConfig(),
 )

--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/config/ConfigModule.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/config/ConfigModule.kt
@@ -18,4 +18,5 @@ fun configModule(vararg profiles: String) =
 
     single { appConfig.openSearch }
     single { appConfig.dispatcherClient }
+    single { appConfig.healthCheck }
   }

--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/dispatcher/EventDispatcherClient.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/dispatcher/EventDispatcherClient.kt
@@ -5,8 +5,8 @@ import ch.srgssr.pillarbox.monitoring.benchmark.timed
 import ch.srgssr.pillarbox.monitoring.cache.LRUCache
 import ch.srgssr.pillarbox.monitoring.exception.HttpClientException
 import ch.srgssr.pillarbox.monitoring.flow.chunked
+import ch.srgssr.pillarbox.monitoring.log.debug
 import ch.srgssr.pillarbox.monitoring.log.error
-import ch.srgssr.pillarbox.monitoring.log.info
 import ch.srgssr.pillarbox.monitoring.log.logger
 import ch.srgssr.pillarbox.monitoring.log.trace
 import ch.srgssr.pillarbox.monitoring.opensearch.model.EventRequest
@@ -63,7 +63,7 @@ class EventDispatcherClient(
         capacity = config.bufferCapacity,
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
       ).chunked(config.saveChunkSize)
-      .onEach { logger.info { "Start processing next ${it.size} events" } }
+      .onEach { logger.debug { "Start processing next ${it.size} events" } }
       .map { events ->
         StatsTracker.increment("nonDroppedEvents", events.size)
 
@@ -77,14 +77,20 @@ class EventDispatcherClient(
             }
 
         val nonStartEvents =
-          events
-            .filter { it.eventName != "START" }
-            .onEach { it.session = sessionCache.get(it.sessionId) }
-            .filter { it.session != null }
-            .also { StatsTracker.increment("cacheHits", it.size) }
+          events.filter { it.eventName != "START" }.onEach {
+            it.session =
+              sessionCache.get(it.sessionId)
+          }
+        val cachedNonStartEvents = nonStartEvents.filter { it.session != null }
 
-        startEvents + nonStartEvents
-      }.onEach { logger.info { "Adding ${it.size} events to next save batch" } }
+        logger.debug {
+          "${nonStartEvents.size - cachedNonStartEvents.size} event(s) dropped: session not found in cache"
+        }
+
+        StatsTracker.increment("cacheHits", cachedNonStartEvents.size)
+
+        startEvents + cachedNonStartEvents
+      }.onEach { logger.debug { "Adding ${it.size} events to next save batch" } }
       .onEach { this.saveEvents(it) }
       .catch { e ->
         logger.error(e) { "Terminal failure in event pipeline: ${e.message}" }
@@ -100,9 +106,9 @@ class EventDispatcherClient(
         eventRepository.saveAll(events)
       }
     } catch (e: HttpClientException) {
-      logger.error("An connection error occurred while saving the current batch", e)
+      logger.error("Failed to save batch of ${events.size} event(s): HTTP error", e)
     } catch (e: Exception) {
-      logger.error("An unexpected error occurred while saving the current batch", e)
+      logger.error("Failed to save batch of ${events.size} event(s): unexpected error", e)
     }
   }
 }

--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/dispatcher/EventFlowProvider.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/dispatcher/EventFlowProvider.kt
@@ -74,7 +74,7 @@ class EventFlowProvider(
         close(e)
       }
 
-      awaitClose { logger.info("SSE flow closed") }
+      awaitClose { logger.warn("SSE flow closed") }
     }.retryWhen(
       config.sseRetry.toRetryWhen(
         onRetry = { cause, attempt, delayMillis ->

--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/health/HealthCheckConfig.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/health/HealthCheckConfig.kt
@@ -1,0 +1,20 @@
+package ch.srgssr.pillarbox.monitoring.health
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Configuration for the HTTP health check server.
+ *
+ * @property port The port on which the health check server listens.
+ * @property inactivityThreshold Duration of event inactivity after which the application is considered unhealthy.
+ * @property gracePeriod Time given to in-flight requests to complete before the server begins shutting down.
+ * @property shutdownTimeout Maximum time to wait for the server to stop before forcing termination.
+ */
+data class HealthCheckConfig(
+  val port: Int = 8081,
+  val inactivityThreshold: Duration = 5.minutes,
+  val gracePeriod: Duration = 1.seconds,
+  val shutdownTimeout: Duration = 5.seconds,
+)

--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/health/HealthCheckModule.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/health/HealthCheckModule.kt
@@ -1,0 +1,13 @@
+package ch.srgssr.pillarbox.monitoring.health
+
+import org.koin.dsl.module
+
+/**
+ * Koin module for the health check server.
+ *
+ * @see [HealthCheckServer]
+ */
+fun healthCheckModule() =
+  module {
+    single { HealthCheckServer(get()) }
+  }

--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/health/HealthCheckServer.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/health/HealthCheckServer.kt
@@ -1,0 +1,73 @@
+package ch.srgssr.pillarbox.monitoring.health
+
+import ch.srgssr.pillarbox.monitoring.benchmark.StatsTracker
+import ch.srgssr.pillarbox.monitoring.log.info
+import ch.srgssr.pillarbox.monitoring.log.logger
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.EmbeddedServer
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+
+/**
+ * Lightweight HTTP server exposing a single `/health` endpoint for ALB health checks.
+ *
+ * Returns 200 when the application has processed events within the configured
+ * [HealthCheckConfig.inactivityThreshold], and 503 otherwise.
+ *
+ * Registers a JVM shutdown hook so the server drains in-flight requests gracefully
+ * before the process exits on SIGTERM.
+ *
+ * @property config Health check server configuration.
+ */
+class HealthCheckServer(
+  val config: HealthCheckConfig,
+) {
+  private companion object {
+    val logger = logger()
+  }
+
+  private var engine: EmbeddedServer<*, *>? = null
+  private var shutdownHook: Thread? = null
+
+  /**
+   * Starts the health check server and registers a JVM shutdown hook to stop it gracefully on exit.
+   */
+  fun start() {
+    logger.info { "Starting health check server on port ${config.port}" }
+
+    engine =
+      embeddedServer(CIO, port = config.port) {
+        routing {
+          get("/health") {
+            if (StatsTracker.isActive(config.inactivityThreshold)) {
+              call.respondText("OK")
+            } else {
+              call.respondText("Service Unavailable", status = HttpStatusCode.ServiceUnavailable)
+            }
+          }
+        }
+      }.start(wait = false)
+
+    shutdownHook =
+      Thread {
+        logger.info("Stopping health check server...")
+        stop()
+      }.also { Runtime.getRuntime().addShutdownHook(it) }
+  }
+
+  /**
+   * Stops the health check server, waiting up to [HealthCheckConfig.gracePeriod] for in-flight
+   * requests to complete before forcing shutdown after [HealthCheckConfig.shutdownTimeout].
+   * Also removes the JVM shutdown hook registered during [start].
+   */
+  fun stop() {
+    engine?.stop(
+      gracePeriodMillis = config.gracePeriod.inWholeMilliseconds,
+      timeoutMillis = config.shutdownTimeout.inWholeMilliseconds,
+    )
+    shutdownHook?.let { runCatching { Runtime.getRuntime().removeShutdownHook(it) } }
+  }
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/opensearch/model/EventRequestDataConverter.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/opensearch/model/EventRequestDataConverter.kt
@@ -1,5 +1,7 @@
 package ch.srgssr.pillarbox.monitoring.opensearch.model
 
+import ch.srgssr.pillarbox.monitoring.log.logger
+import ch.srgssr.pillarbox.monitoring.log.warn
 import tools.jackson.databind.util.StdConverter
 
 /**
@@ -13,6 +15,10 @@ import tools.jackson.databind.util.StdConverter
  * @see [DataProcessor]
  */
 internal class EventRequestDataConverter : StdConverter<EventRequest, EventRequest>() {
+  private companion object {
+    val logger = logger()
+  }
+
   private val processors =
     listOf(
       DeviceNameProcessor(),
@@ -24,15 +30,26 @@ internal class EventRequestDataConverter : StdConverter<EventRequest, EventReque
       ClampingNumberDataProcessor(),
     )
 
-  @Suppress("UNCHECKED_CAST")
+  @Suppress("UNCHECKED_CAST", "TooGenericExceptionCaught")
   override fun convert(value: EventRequest): EventRequest {
-    (value.data as? MutableMap<String, Any?>)?.let { data ->
-      processors
-        .forEach { processor ->
-          if (processor.shouldProcess(value.eventName, data)) {
-            value.data = processor.process(data)
+    val data =
+      (value.data as? MutableMap<String, Any?>) ?: run {
+        logger.warn {
+          "Event '${value.eventName}' (session=${value.sessionId}) has unexpected data type — skipping processors"
+        }
+        return value
+      }
+
+    processors.forEach { processor ->
+      if (processor.shouldProcess(value.eventName, data)) {
+        try {
+          value.data = processor.process(data)
+        } catch (e: Exception) {
+          logger.warn(e) {
+            "Processor ${processor::class.simpleName} failed on event '${value.eventName}' (session=${value.sessionId})"
           }
         }
+      }
     }
 
     return value

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,3 +2,6 @@ dispatcher-client:
   buffer-capacity: 1000
   cache-size: 5000
   save-chunk-size: 1
+
+health-check:
+  port: 8081

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -2,3 +2,7 @@ dispatcher-client:
   buffer-capacity: 30000
   cache-size: 200000
   save-chunk-size: 6000
+
+health-check:
+  port: 8081
+  inactivity-threshold: 1m

--- a/src/main/resources/logback-local.xml
+++ b/src/main/resources/logback-local.xml
@@ -1,3 +1,15 @@
-<configuration>
+<included>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+      <pattern>
+        %green(%d{yyyy-MM-dd HH:mm:ss}) %magenta([%thread]) %blue(%-5level) %yellow(%logger{36}) - %msg%n
+      </pattern>
+    </encoder>
+  </appender>
+
   <logger name="ch.srgssr.pillarbox.monitoring" level="TRACE"/>
-</configuration>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</included>

--- a/src/main/resources/logback-prod.xml
+++ b/src/main/resources/logback-prod.xml
@@ -1,3 +1,13 @@
-<configuration>
+<included>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+      <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
   <logger name="ch.srgssr.pillarbox.monitoring.opensearch.model" level="ERROR"/>
-</configuration>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</included>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -5,18 +5,6 @@
   <property name="profile" value="${PILLARBOX_PROFILE:-local}"/>
   <include resource="logback-${profile}.xml"/>
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-      <pattern>
-        %green(%d{yyyy-MM-dd HH:mm:ss}) %magenta([%thread]) %blue(%-5level) %yellow(%logger{36}) - %msg%n
-      </pattern>
-    </encoder>
-  </appender>
-
   <logger name="io.ktor" level="INFO"/>
   <logger name="kotlinx.coroutines" level="INFO"/>
-
-  <root level="INFO">
-    <appender-ref ref="STDOUT"/>
-  </root>
 </configuration>

--- a/src/test/kotlin/ch/srgssr/pillarbox/monitoring/DataTransferApplicationRunnerTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/monitoring/DataTransferApplicationRunnerTest.kt
@@ -2,6 +2,8 @@ package ch.srgssr.pillarbox.monitoring
 
 import ch.srgssr.pillarbox.monitoring.benchmark.BenchmarkScheduledLogger
 import ch.srgssr.pillarbox.monitoring.dispatcher.EventDispatcherClient
+import ch.srgssr.pillarbox.monitoring.health.HealthCheckConfig
+import ch.srgssr.pillarbox.monitoring.health.HealthCheckServer
 import ch.srgssr.pillarbox.monitoring.opensearch.setup.OpenSearchSetupService
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.ShouldSpec
@@ -22,18 +24,18 @@ class DataTransferApplicationRunnerTest :
 
     val mockOpenSearchSetup = mockk<OpenSearchSetupService>()
     val mockDispatcherClient = mockk<EventDispatcherClient>()
+    val mockHealthCheckServer = mockk<HealthCheckServer>()
 
-    val runner = DataTransferApplicationRunner(mockOpenSearchSetup, mockDispatcherClient)
+    val runner = DataTransferApplicationRunner(mockOpenSearchSetup, mockDispatcherClient, mockHealthCheckServer)
 
     beforeTest {
       clearAllMocks()
+      every { mockHealthCheckServer.start() } just Runs
     }
 
-    should("run OpenSearch setup and start the event dispatcher client") {
-      val mockDispatcherJob = mockk<Job>()
+    should("start the health check server, run OpenSearch setup, then start the event dispatcher client") {
       coEvery { mockOpenSearchSetup.start() } just Runs
       coEvery { mockDispatcherClient.start() } just Runs
-      coEvery { mockDispatcherJob.join() } just Runs
       mockkObject(BenchmarkScheduledLogger)
 
       val benchmarkJob = mockk<Job>()
@@ -45,6 +47,7 @@ class DataTransferApplicationRunnerTest :
       }
 
       coVerifyOrder {
+        mockHealthCheckServer.start()
         mockOpenSearchSetup.start()
         mockDispatcherClient.start()
         benchmarkJob.cancel()

--- a/src/test/kotlin/ch/srgssr/pillarbox/monitoring/benchmark/BenchmarkScheduledLoggerTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/monitoring/benchmark/BenchmarkScheduledLoggerTest.kt
@@ -13,7 +13,7 @@ class BenchmarkScheduledLoggerTest :
     should("run one scheduled iteration without throwing") {
       runTest {
         val dispatcher = StandardTestDispatcher(testScheduler)
-        val job = BenchmarkScheduledLogger.start(dispatcher)
+        val job = BenchmarkScheduledLogger.start(context = dispatcher)
         advanceTimeBy(1_000)
         job.cancel()
       }

--- a/src/test/kotlin/ch/srgssr/pillarbox/monitoring/benchmark/StatsTrackerTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/monitoring/benchmark/StatsTrackerTest.kt
@@ -2,12 +2,17 @@ package ch.srgssr.pillarbox.monitoring.benchmark
 
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.longs.shouldBeExactly
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 class StatsTrackerTest :
   ShouldSpec({
 
     beforeTest {
-      // Reset state before each test
       StatsTracker.getAndResetAll()
     }
 
@@ -37,8 +42,26 @@ class StatsTrackerTest :
       snapshot["one"]!! shouldBeExactly 1L
       snapshot["two"]!! shouldBeExactly 2L
 
-      // After reset, all keys should return 0
       StatsTracker["one"] shouldBeExactly 0L
       StatsTracker["two"] shouldBeExactly 0L
+    }
+
+    should("update lastSeenAt on increment") {
+      val before = Clock.System.now()
+      StatsTracker.increment("key", 1L)
+
+      StatsTracker.lastSeenAt.shouldNotBeNull() shouldNotBe before
+    }
+
+    should("report active immediately after increment") {
+      StatsTracker.increment("key", 1L)
+
+      StatsTracker.isActive(1.minutes) shouldBe true
+    }
+
+    should("report inactive when threshold is already exceeded") {
+      StatsTracker.increment("key", 1L)
+
+      StatsTracker.isActive(0.seconds) shouldBe false
     }
   })

--- a/src/test/kotlin/ch/srgssr/pillarbox/monitoring/health/HealthCheckServerTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/monitoring/health/HealthCheckServerTest.kt
@@ -1,0 +1,47 @@
+package ch.srgssr.pillarbox.monitoring.health
+
+import ch.srgssr.pillarbox.monitoring.benchmark.StatsTracker
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.request.get
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import kotlin.time.Duration.Companion.minutes
+
+class HealthCheckServerTest :
+  ShouldSpec({
+
+    val config = HealthCheckConfig(port = 18081, inactivityThreshold = 1.minutes)
+    val server = HealthCheckServer(config)
+    val client = HttpClient(CIO)
+
+    beforeSpec {
+      mockkObject(StatsTracker)
+      server.start()
+    }
+
+    afterSpec {
+      client.close()
+      server.stop()
+      unmockkObject(StatsTracker)
+    }
+
+    should("return 200 when the application is active") {
+      every { StatsTracker.isActive(any()) } returns true
+
+      val response = client.get("http://localhost:18081/health")
+
+      response.status.value shouldBe 200
+    }
+
+    should("return 503 when the application is inactive") {
+      every { StatsTracker.isActive(any()) } returns false
+
+      val response = client.get("http://localhost:18081/health")
+
+      response.status.value shouldBe 503
+    }
+  })


### PR DESCRIPTION
## Description

The application had no way to signal to the infrastructure that it had stopped processing events, this change makes that state observable via an HTTP health check.

## Changes Made

- Stats tracker now records when the last event was seen, exposing whether the application has been active within a configurable window.
- Benchmark logger warns at runtime when the inactivity threshold is exceeded.
- A /health endpoint returns 200 while events are flowing and 503 when the application goes silent.

Logging changes:

- Stats and throughput metrics demoted to debug, invisible in production
- Noisy per-batch pipeline logs demoted to debug
- Error messages enriched with enough context to aid post-mortem debugging
- Data conversion failures now surface as warnings instead of being silently swallowed
- Production log output stripped of ANSI colors for CloudWatch compatibility

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
