### PR TITLE
fix(dispatcher): drop malformed events to avoid tearing down the SSE stream

### DIFF
--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/dispatcher/EventFlowProvider.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/dispatcher/EventFlowProvider.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.retryWhen
+import tools.jackson.core.JacksonException
 import tools.jackson.databind.json.JsonMapper
 
 /**
@@ -64,9 +65,16 @@ class EventFlowProvider(
     callbackFlow {
       try {
         httpClient.sse("") {
-          incoming.collect {
-            val event = jsonMapper.readValue(it.data, EventRequest::class.java)
-            trySend(event).isSuccess
+          incoming.collect { event ->
+            val parsed =
+              try {
+                jsonMapper.readValue(event.data, EventRequest::class.java)
+              } catch (e: JacksonException) {
+                logger.warn(e) { "Dropping malformed event: ${e.message}" }
+                null
+              }
+
+            parsed?.let { trySend(it).isSuccess }
           }
         }
       } catch (e: Exception) {

--- a/src/test/kotlin/ch/srgssr/pillarbox/monitoring/dispatcher/EventFlowProviderTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/monitoring/dispatcher/EventFlowProviderTest.kt
@@ -1,6 +1,7 @@
 package ch.srgssr.pillarbox.monitoring.dispatcher
 
 import ch.srgssr.pillarbox.monitoring.test.eventRequest
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
@@ -12,7 +13,6 @@ import okhttp3.mockwebserver.MockWebServer
 import org.koin.test.KoinTest
 import org.koin.test.inject
 import tools.jackson.databind.json.JsonMapper
-import java.util.concurrent.TimeUnit
 
 class EventFlowProviderTest :
   ShouldSpec(),
@@ -24,16 +24,14 @@ class EventFlowProviderTest :
   init {
     var mockWebServer = MockWebServer()
 
-    beforeTest {
+    beforeEach {
       mockWebServer = MockWebServer()
       mockWebServer.start(config.uri.port)
     }
 
-    afterTest {
+    afterEach {
       mockWebServer.shutdown()
     }
-
-    // In EventFlowProviderTest.kt
 
     should("emit EventRequests from SSE stream") {
       runTest {
@@ -51,12 +49,81 @@ class EventFlowProviderTest :
             .setBody(sseData),
         )
 
-        // Use take(2) because you are asserting on 2 events
         val events = provider.start().take(2).toList()
 
         events shouldHaveSize 2
         events[0].eventName shouldBe "START"
         events[1].eventName shouldBe "HEARTBEAT"
+      }
+    }
+
+    context("connection resilience") {
+      fun noRetryProvider() =
+        EventFlowProvider(
+          config.copy(sseRetry = config.sseRetry.copy(maxAttempts = 0)),
+          jsonMapper,
+        )
+
+      should("skip a malformed event without consuming the retry budget") {
+        runTest {
+          val event1 = eventRequest { eventName = "START" }
+          val event2 = eventRequest { eventName = "HEARTBEAT" }
+          val malformed = """{"session_id":"abc","event_name":"ERROR","@timestamp":"123'","version":1,"data":{}}"""
+
+          val sseData =
+            "data: ${jsonMapper.writeValueAsString(event1)}\n\n" +
+              "data: $malformed\n\n" +
+              "data: ${jsonMapper.writeValueAsString(event2)}\n\n"
+
+          mockWebServer.enqueue(
+            MockResponse()
+              .setResponseCode(200)
+              .setHeader("Content-Type", "text/event-stream")
+              .setBody(sseData),
+          )
+
+          val events = noRetryProvider().start().take(2).toList()
+
+          events shouldHaveSize 2
+          events[0].eventName shouldBe "START"
+          events[1].eventName shouldBe "HEARTBEAT"
+          mockWebServer.requestCount shouldBe 1
+        }
+      }
+
+      should("terminate the stream when a connection failure exhausts the retry budget") {
+        runTest {
+          mockWebServer.enqueue(MockResponse().setResponseCode(500))
+
+          shouldThrow<Exception> {
+            noRetryProvider().start().toList()
+          }
+        }
+      }
+
+      should("recover from a transient connection failure while retries remain") {
+        runTest {
+          val event = eventRequest { eventName = "START" }
+
+          mockWebServer.enqueue(MockResponse().setResponseCode(500))
+          mockWebServer.enqueue(
+            MockResponse()
+              .setResponseCode(200)
+              .setHeader("Content-Type", "text/event-stream")
+              .setBody("data: ${jsonMapper.writeValueAsString(event)}\n\n"),
+          )
+
+          val provider =
+            EventFlowProvider(
+              config.copy(sseRetry = config.sseRetry.copy(maxAttempts = 1)),
+              jsonMapper,
+            )
+
+          val events = provider.start().take(1).toList()
+
+          events shouldHaveSize 1
+          events[0].eventName shouldBe "START"
+        }
       }
     }
   }


### PR DESCRIPTION
## Description

A single event with a corrupt field raised a deserialization error that propagated out of the SSE collector and closed the connection. Each reconnect that hit bad data and consumed one of the limited retry attempts, so after a few malformed events the retry budget was exhausted and the application shut down in production.

Event parsing is now resilient on a per-event basis: a malformed payload is logged and skipped while the connection stays open, reserving the reconnect budget for genuine connection failures.

## Changes Made

- Deserialization failures are caught per event and the offending event is dropped with a warning.
- Connection-level retries are preserved for actual transport failures.
- Added tests covering malformed-event skipping and retry exhaustion.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
