### PR TITLE
fix(dispatcher): keep the SSE reader loop fast to avoid stalling the sink

### DIFF
--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/DataTransferApplicationRunner.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/DataTransferApplicationRunner.kt
@@ -1,10 +1,12 @@
 package ch.srgssr.pillarbox.monitoring
 
 import ch.srgssr.pillarbox.monitoring.benchmark.BenchmarkScheduledLogger
+import ch.srgssr.pillarbox.monitoring.benchmark.timed
 import ch.srgssr.pillarbox.monitoring.dispatcher.EventDispatcherClient
 import ch.srgssr.pillarbox.monitoring.health.HealthCheckServer
 import ch.srgssr.pillarbox.monitoring.log.error
 import ch.srgssr.pillarbox.monitoring.log.logger
+import ch.srgssr.pillarbox.monitoring.opensearch.model.UserAgentProcessor
 import ch.srgssr.pillarbox.monitoring.opensearch.setup.OpenSearchSetupService
 
 /**
@@ -36,6 +38,9 @@ class DataTransferApplicationRunner(
     healthCheckServer.start()
 
     openSearchSetupService.start()
+
+    logger.info("Warming up the user agent analyzer...")
+    timed("UserAgentProcessor.warmUp") { UserAgentProcessor.warmUp() }
 
     val benchmarkJob = BenchmarkScheduledLogger.start()
     try {

--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/dispatcher/EventDispatcherClient.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/dispatcher/EventDispatcherClient.kt
@@ -9,28 +9,33 @@ import ch.srgssr.pillarbox.monitoring.log.debug
 import ch.srgssr.pillarbox.monitoring.log.error
 import ch.srgssr.pillarbox.monitoring.log.logger
 import ch.srgssr.pillarbox.monitoring.log.trace
+import ch.srgssr.pillarbox.monitoring.log.warn
 import ch.srgssr.pillarbox.monitoring.opensearch.model.EventRequest
 import ch.srgssr.pillarbox.monitoring.opensearch.repository.EventRepository
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import tools.jackson.core.JacksonException
+import tools.jackson.databind.json.JsonMapper
 
 /**
  * Service responsible for consuming events from a remote event dispatcher service via Server-Sent Events (SSE),
  * enriching them with session metadata, and persisting them in bulk.
  *
- * @property eventFlowProvider Provides a reactive flow of incoming [EventRequest]s.
+ * @property eventFlowProvider Provides a reactive flow of raw event payloads.
  * @property eventRepository The persistence layer for storing enriched events.
  * @property config Configuration for the buffer size, cache and batching.
+ * @property jsonMapper Jackson's [JsonMapper] used to deserialize incoming event payloads.
  */
 class EventDispatcherClient(
   private val eventFlowProvider: EventFlowProvider,
   private val eventRepository: EventRepository,
   private val config: EventDispatcherClientConfig,
+  private val jsonMapper: JsonMapper,
 ) {
   private companion object {
     /**
@@ -45,15 +50,16 @@ class EventDispatcherClient(
    * Starts the reactive event processing pipeline.
    *
    * The pipeline:
-   * - Subscribes to the event stream.
+   * - Subscribes to the raw event stream.
    * - Tracks basic metrics for incoming and processed events.
    * - Buffers events with overflow policy (dropping oldest).
    * - Batches events for efficient saving.
+   * - Deserializes and enriches each batch of raw payloads.
    * - Separates "START" events to extract session data and populate the cache.
    * - Enriches follow-up events with cached session info.
    * - Persists all valid events using the repository.
    *
-   * This method launches the flow in a background coroutine and returns the running [Job].
+   * This method suspends until the flow completes or the calling coroutine is cancelled.
    */
   suspend fun start() =
     eventFlowProvider
@@ -64,6 +70,11 @@ class EventDispatcherClient(
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
       ).chunked(config.saveChunkSize)
       .onEach { logger.debug { "Start processing next ${it.size} events" } }
+      .map { rawEvents ->
+        timed("EventDispatcherClient.parseEvents") {
+          rawEvents.mapNotNull(::parseEvent)
+        }
+      }.filter { it.isNotEmpty() }
       .map { events ->
         StatsTracker.increment("nonDroppedEvents", events.size)
 
@@ -96,6 +107,20 @@ class EventDispatcherClient(
         logger.error(e) { "Terminal failure in event pipeline: ${e.message}" }
         throw e
       }.collect()
+
+  /**
+   * Deserializes a raw event payload into an [EventRequest].
+   *
+   * Malformed payloads are dropped, logged and counted under the `malformedEvents` statistic.
+   */
+  private fun parseEvent(data: String): EventRequest? =
+    try {
+      jsonMapper.readValue(data, EventRequest::class.java)
+    } catch (e: JacksonException) {
+      StatsTracker.increment("malformedEvents")
+      logger.warn(e) { "Dropping malformed event: ${e.message}" }
+      null
+    }
 
   @Suppress("TooGenericExceptionCaught")
   private suspend fun saveEvents(events: List<EventRequest>) {

--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/dispatcher/EventDispatcherModule.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/dispatcher/EventDispatcherModule.kt
@@ -10,6 +10,6 @@ import org.koin.dsl.module
  */
 fun eventDispatcherModule() =
   module {
-    single { EventFlowProvider(get(), get()) }
-    single { EventDispatcherClient(get(), get(), get()) }
+    single { EventFlowProvider(get()) }
+    single { EventDispatcherClient(get(), get(), get(), get()) }
   }

--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/dispatcher/EventFlowProvider.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/dispatcher/EventFlowProvider.kt
@@ -1,9 +1,10 @@
 package ch.srgssr.pillarbox.monitoring.dispatcher
 
+import ch.srgssr.pillarbox.monitoring.benchmark.StatsTracker
+import ch.srgssr.pillarbox.monitoring.log.debug
 import ch.srgssr.pillarbox.monitoring.log.error
 import ch.srgssr.pillarbox.monitoring.log.logger
 import ch.srgssr.pillarbox.monitoring.log.warn
-import ch.srgssr.pillarbox.monitoring.opensearch.model.EventRequest
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.HttpTimeout
@@ -16,23 +17,19 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.retryWhen
-import tools.jackson.core.JacksonException
-import tools.jackson.databind.json.JsonMapper
 
 /**
- * Provides a reactive [Flow] of [EventRequest]s by connecting to a remote Server-Sent Events (SSE) endpoint.
+ * Provides a reactive [Flow] of raw event payloads by connecting to a remote Server-Sent Events (SSE) endpoint.
  *
  * This component is responsible for:
  * - Establishing the connection to the SSE endpoint configured in [EventDispatcherClientConfig].
- * - Mapping the SSE stream to a stream of [EventRequest] objects.
+ * - Forwarding the raw SSE data payloads downstream, deserialization is handled by the consumer.
  * - Applying retry logic in case of transient failures, with support for logging retry attempts.
  *
  * @property config The SSE client configuration including URI and retry strategy.
- * @property jsonMapper Jackson's [JsonMapper] used to serialize event objects.
  */
 class EventFlowProvider(
   private val config: EventDispatcherClientConfig,
-  private val jsonMapper: JsonMapper,
 ) {
   private companion object {
     /**
@@ -56,25 +53,28 @@ class EventFlowProvider(
     }
 
   /**
-   * Creates and returns a [Flow] of [EventRequest]s from the SSE endpoint.
+   * Creates and returns a [Flow] of raw event payloads from the SSE endpoint.
    *
-   * @return A [Flow] that emits [EventRequest]s received from the remote SSE endpoint.
+   * Payloads that cannot be handed off because the flow buffer is full are dropped,
+   * logged and counted under the `sseDroppedEvents` statistic.
+   *
+   * @return A [Flow] that emits the raw `data` payload of each SSE event.
    */
   @Suppress("TooGenericExceptionCaught")
-  fun start(): Flow<EventRequest> =
+  fun start(): Flow<String> =
     callbackFlow {
       try {
         httpClient.sse("") {
           incoming.collect { event ->
-            val parsed =
-              try {
-                jsonMapper.readValue(event.data, EventRequest::class.java)
-              } catch (e: JacksonException) {
-                logger.warn(e) { "Dropping malformed event: ${e.message}" }
-                null
+            event.data?.let { data ->
+              val result = trySend(data)
+              if (result.isClosed) {
+                logger.debug { "Dropping event: SSE flow is closed" }
+              } else if (result.isFailure) {
+                StatsTracker.increment("sseDroppedEvents")
+                logger.warn { "Dropping event: SSE flow buffer is full" }
               }
-
-            parsed?.let { trySend(it).isSuccess }
+            }
           }
         }
       } catch (e: Exception) {

--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/opensearch/model/UserAgentProcessor.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/opensearch/model/UserAgentProcessor.kt
@@ -11,13 +11,39 @@ import nl.basjes.parse.useragent.UserAgentAnalyzer
  * It also determines whether the user agent belongs to a robot.
  */
 internal class UserAgentProcessor : DataProcessor {
-  private companion object {
-    val userAgentAnalyzer: UserAgentAnalyzer =
+  companion object {
+    /**
+     * Number of sample user agents to run through the analyzer during [warmUp].
+     */
+    private const val PREHEAT_ITERATIONS = 1_000L
+
+    /**
+     * Analyzer restricted to the fields used by this processor, initialized eagerly at build time.
+     */
+    private val userAgentAnalyzer: UserAgentAnalyzer =
       UserAgentAnalyzer
         .newBuilder()
         .hideMatcherLoadStats()
         .withCache(10000)
+        .withField(UserAgent.AGENT_NAME)
+        .withField(UserAgent.AGENT_VERSION)
+        .withField(UserAgent.AGENT_CLASS)
+        .withField(UserAgent.AGENT_SECURITY)
+        .withField(UserAgent.DEVICE_NAME)
+        .withField(UserAgent.DEVICE_CLASS)
+        .withField(UserAgent.LAYOUT_ENGINE_CLASS)
+        .withField(UserAgent.OPERATING_SYSTEM_NAME)
+        .withField(UserAgent.OPERATING_SYSTEM_VERSION)
+        .immediateInitialization()
         .build()
+
+    /**
+     * Warms up the analyzer by running sample user agents through it.
+     * Call once at application start-up, before event consumption begins.
+     */
+    fun warmUp() {
+      userAgentAnalyzer.preHeat(PREHEAT_ITERATIONS)
+    }
   }
 
   private fun isHackerOrRobot(userAgent: UserAgent): Boolean =

--- a/src/test/kotlin/ch/srgssr/pillarbox/monitoring/dispatcher/EventDispatcherClientTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/monitoring/dispatcher/EventDispatcherClientTest.kt
@@ -12,9 +12,19 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.flow.flowOf
+import tools.jackson.databind.DeserializationFeature
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.KotlinModule
 
 class EventDispatcherClientTest :
   ShouldSpec({
+
+    val jsonMapper =
+      JsonMapper
+        .builder()
+        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        .addModule(KotlinModule.Builder().build())
+        .build()
 
     val mockEventFlowProvider = mockk<EventFlowProvider>()
     val mockEventRepository = mockk<EventRepository>(relaxed = true)
@@ -24,6 +34,7 @@ class EventDispatcherClientTest :
         eventFlowProvider = mockEventFlowProvider,
         eventRepository = mockEventRepository,
         config = EventDispatcherClientConfig(),
+        jsonMapper = jsonMapper,
       )
 
     beforeTest {
@@ -39,7 +50,7 @@ class EventDispatcherClientTest :
           data = sessionData
         }
 
-      every { mockEventFlowProvider.start() } returns flowOf(event)
+      every { mockEventFlowProvider.start() } returns flowOf(jsonMapper.writeValueAsString(event))
 
       dispatcherClient.start()
 
@@ -73,7 +84,11 @@ class EventDispatcherClientTest :
           data = mapOf("error_name" to "ConnectionError")
         }
 
-      every { mockEventFlowProvider.start() } returns flowOf(start, error)
+      every { mockEventFlowProvider.start() } returns
+        flowOf(
+          jsonMapper.writeValueAsString(start),
+          jsonMapper.writeValueAsString(error),
+        )
 
       dispatcherClient.start()
 
@@ -84,5 +99,37 @@ class EventDispatcherClientTest :
       saved shouldHaveSize 2
       saved.forEach { it.sessionId shouldBe commonSessionId }
       saved.forEach { it.session shouldBe sessionData }
+    }
+
+    should("skip malformed payloads and save the valid ones") {
+      val event =
+        eventRequest {
+          eventName = "START"
+          session = null
+          data = mapOf("version" to 1)
+        }
+
+      every { mockEventFlowProvider.start() } returns
+        flowOf(
+          """{"not valid json""",
+          jsonMapper.writeValueAsString(event),
+        )
+
+      dispatcherClient.start()
+
+      val slot = slot<List<EventRequest>>()
+      coVerify(exactly = 1) { mockEventRepository.saveAll(capture(slot)) }
+
+      val saved = slot.captured
+      saved shouldHaveSize 1
+      saved.first().sessionId shouldBe event.sessionId
+    }
+
+    should("not save anything when all payloads are malformed") {
+      every { mockEventFlowProvider.start() } returns flowOf("""{"not valid json""")
+
+      dispatcherClient.start()
+
+      coVerify(exactly = 0) { mockEventRepository.saveAll(any()) }
     }
   })

--- a/src/test/kotlin/ch/srgssr/pillarbox/monitoring/dispatcher/EventFlowProviderTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/monitoring/dispatcher/EventFlowProviderTest.kt
@@ -33,14 +33,12 @@ class EventFlowProviderTest :
       mockWebServer.shutdown()
     }
 
-    should("emit EventRequests from SSE stream") {
+    should("emit raw event payloads from SSE stream") {
       runTest {
-        val event1 = eventRequest { eventName = "START" }
-        val event2 = eventRequest { eventName = "HEARTBEAT" }
+        val event1 = jsonMapper.writeValueAsString(eventRequest { eventName = "START" })
+        val event2 = jsonMapper.writeValueAsString(eventRequest { eventName = "HEARTBEAT" })
 
-        val sseData =
-          "data: ${jsonMapper.writeValueAsString(event1)}\n\n" +
-            "data: ${jsonMapper.writeValueAsString(event2)}\n\n"
+        val sseData = "data: $event1\n\ndata: $event2\n\n"
 
         mockWebServer.enqueue(
           MockResponse()
@@ -52,8 +50,30 @@ class EventFlowProviderTest :
         val events = provider.start().take(2).toList()
 
         events shouldHaveSize 2
-        events[0].eventName shouldBe "START"
-        events[1].eventName shouldBe "HEARTBEAT"
+        events[0] shouldBe event1
+        events[1] shouldBe event2
+      }
+    }
+
+    should("pass payloads through without parsing or validating them") {
+      runTest {
+        val event = jsonMapper.writeValueAsString(eventRequest { eventName = "START" })
+        val malformed = """{"session_id":"abc","event_name":"ERROR","@timestamp":"123'","version":1,"data":{}"""
+
+        val sseData = "data: $event\n\ndata: $malformed\n\n"
+
+        mockWebServer.enqueue(
+          MockResponse()
+            .setResponseCode(200)
+            .setHeader("Content-Type", "text/event-stream")
+            .setBody(sseData),
+        )
+
+        val events = provider.start().take(2).toList()
+
+        events shouldHaveSize 2
+        events[0] shouldBe event
+        events[1] shouldBe malformed
       }
     }
 
@@ -61,35 +81,7 @@ class EventFlowProviderTest :
       fun noRetryProvider() =
         EventFlowProvider(
           config.copy(sseRetry = config.sseRetry.copy(maxAttempts = 0)),
-          jsonMapper,
         )
-
-      should("skip a malformed event without consuming the retry budget") {
-        runTest {
-          val event1 = eventRequest { eventName = "START" }
-          val event2 = eventRequest { eventName = "HEARTBEAT" }
-          val malformed = """{"session_id":"abc","event_name":"ERROR","@timestamp":"123'","version":1,"data":{}}"""
-
-          val sseData =
-            "data: ${jsonMapper.writeValueAsString(event1)}\n\n" +
-              "data: $malformed\n\n" +
-              "data: ${jsonMapper.writeValueAsString(event2)}\n\n"
-
-          mockWebServer.enqueue(
-            MockResponse()
-              .setResponseCode(200)
-              .setHeader("Content-Type", "text/event-stream")
-              .setBody(sseData),
-          )
-
-          val events = noRetryProvider().start().take(2).toList()
-
-          events shouldHaveSize 2
-          events[0].eventName shouldBe "START"
-          events[1].eventName shouldBe "HEARTBEAT"
-          mockWebServer.requestCount shouldBe 1
-        }
-      }
 
       should("terminate the stream when a connection failure exhausts the retry budget") {
         runTest {
@@ -103,26 +95,25 @@ class EventFlowProviderTest :
 
       should("recover from a transient connection failure while retries remain") {
         runTest {
-          val event = eventRequest { eventName = "START" }
+          val event = jsonMapper.writeValueAsString(eventRequest { eventName = "START" })
 
           mockWebServer.enqueue(MockResponse().setResponseCode(500))
           mockWebServer.enqueue(
             MockResponse()
               .setResponseCode(200)
               .setHeader("Content-Type", "text/event-stream")
-              .setBody("data: ${jsonMapper.writeValueAsString(event)}\n\n"),
+              .setBody("data: $event\n\n"),
           )
 
           val provider =
             EventFlowProvider(
               config.copy(sseRetry = config.sseRetry.copy(maxAttempts = 1)),
-              jsonMapper,
             )
 
           val events = provider.start().take(1).toList()
 
           events shouldHaveSize 1
-          events[0].eventName shouldBe "START"
+          events[0] shouldBe event
         }
       }
     }


### PR DESCRIPTION
## Description

The SSE collector was deserializing every payload inline before handing it off, and the first events through the pipeline paid the YAUAA analyzer's lazy initialization cost. Both slowed the reader loop enough for this consumer to fall behind and stall the SSE sink.

## Changes Made

- Move JSON deserialization out of EventFlowProvider.
- Drop payloads instead of suspending when the flow buffer is full.
- Initialize the user agent analyzer eagerly.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
