### PR TITLE
feat: normalize and index drm capabilities

### DIFF
--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/opensearch/model/CapabilitiesProcessor.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/opensearch/model/CapabilitiesProcessor.kt
@@ -1,0 +1,87 @@
+package ch.srgssr.pillarbox.monitoring.opensearch.model
+
+/**
+ * A [DataProcessor] that normalizes DRM capability information reported by clients.
+ *
+ * Clients may report security level of a key system using the raw values returned by the platform's
+ * EME implementation.
+ *
+ * This processor rewrites those values into the vendor-specific level names.
+ */
+internal class CapabilitiesProcessor : DataProcessor {
+  /**
+   * Process only on START events.
+   */
+  override fun shouldProcess(
+    eventName: String,
+    data: Map<String, Any?>,
+  ): Boolean = eventName == "START"
+
+  /**
+   * Processes the given data node
+   *
+   * - Normalizes the Widevine and PlayReady security levels found under the `capabilities` node.
+   * - If the `capabilities` node is missing or is not a map, the data is returned unchanged.
+   *
+   * @param data The event data to process (should contain a `capabilities` node).
+   *
+   * @return The enriched data map.
+   */
+  @Suppress("UNCHECKED_CAST")
+  override fun process(data: MutableMap<String, Any?>): MutableMap<String, Any?> {
+    val capabilities = data["capabilities"] as? MutableMap<String, Any?> ?: return data
+
+    capabilities.mapLevel("widevine", { it.toWidevineLevel() })
+    capabilities.mapLevel("playReady", { it.toPlayReadyLevel() })
+
+    return data
+  }
+
+  /**
+   * Applies [transform] to the `level` entry of the given key system, if it exists.
+   *
+   * The receiver is left untouched when the key system is absent, is not a map, or does not hold a
+   * `level` of type [String].
+   *
+   * @param keySystem The name of the key system entry to update, e.g. `widevine` or `playReady`.
+   * @param transform The mapping applied to the raw level value.
+   */
+  @Suppress("UNCHECKED_CAST")
+  private fun MutableMap<String, Any?>.mapLevel(
+    keySystem: String,
+    transform: (String) -> String,
+  ) {
+    val capability = this[keySystem] as? MutableMap<String, Any?> ?: return
+    val level = capability["level"] as? String ?: return
+    capability["level"] = transform(level)
+  }
+}
+
+/**
+ * Converts a raw EME security level into its Widevine equivalent.
+ *
+ * @return The Widevine level name, or the original value if it is unknown.
+ */
+private fun String.toWidevineLevel(): String =
+  when (this) {
+    "SW_SECURE_CRYPTO", "SW_SECURE_DECODE" -> "L3"
+    "HW_SECURE_CRYPTO", "HW_SECURE_DECODE" -> "L2"
+    "HW_SECURE_ALL" -> "L1"
+    else -> this
+  }
+
+/**
+ * Converts a raw EME security level into its PlayReady equivalent.
+ *
+ * @return The PlayReady level name, or the original value if it is unknown.
+ */
+private fun String.toPlayReadyLevel(): String =
+  when (this) {
+    "SW_SECURE_CRYPTO", "SW_SECURE_DECODE",
+    "HW_SECURE_CRYPTO", "HW_SECURE_DECODE",
+    -> "SL2000"
+
+    "HW_SECURE_ALL" -> "SL3000"
+
+    else -> this
+  }

--- a/src/main/kotlin/ch/srgssr/pillarbox/monitoring/opensearch/model/EventRequestDataConverter.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/monitoring/opensearch/model/EventRequestDataConverter.kt
@@ -28,6 +28,7 @@ internal class EventRequestDataConverter : StdConverter<EventRequest, EventReque
       ContentRestrictionProcessor(),
       ErrorProcessor(),
       ClampingNumberDataProcessor(),
+      CapabilitiesProcessor(),
     )
 
   @Suppress("UNCHECKED_CAST", "TooGenericExceptionCaught")

--- a/src/main/resources/opensearch/core_events-template.json
+++ b/src/main/resources/opensearch/core_events-template.json
@@ -140,6 +140,58 @@
                 }
               }
             },
+            "capabilities": {
+              "properties": {
+                "widevine": {
+                  "properties": {
+                    "level": {
+                      "type": "keyword",
+                      "ignore_above": 256
+                    },
+                    "hdcp": {
+                      "type": "keyword",
+                      "ignore_above": 256
+                    }
+                  }
+                },
+                "fairPlay": {
+                  "properties": {
+                    "level": {
+                      "type": "keyword",
+                      "ignore_above": 256
+                    },
+                    "hdcp": {
+                      "type": "keyword",
+                      "ignore_above": 256
+                    }
+                  }
+                },
+                "playReady": {
+                  "properties": {
+                    "level": {
+                      "type": "keyword",
+                      "ignore_above": 256
+                    },
+                    "hdcp": {
+                      "type": "keyword",
+                      "ignore_above": 256
+                    }
+                  }
+                },
+                "clearKey": {
+                  "properties": {
+                    "level": {
+                      "type": "keyword",
+                      "ignore_above": 256
+                    },
+                    "hdcp": {
+                      "type": "keyword",
+                      "ignore_above": 256
+                    }
+                  }
+                }
+              }
+            },
             "device": {
               "properties": {
                 "id": {

--- a/src/main/resources/opensearch/heartbeat_events-template.json
+++ b/src/main/resources/opensearch/heartbeat_events-template.json
@@ -116,6 +116,58 @@
                 }
               }
             },
+            "capabilities": {
+              "properties": {
+                "widevine": {
+                  "properties": {
+                    "level": {
+                      "type": "keyword",
+                      "ignore_above": 256
+                    },
+                    "hdcp": {
+                      "type": "keyword",
+                      "ignore_above": 256
+                    }
+                  }
+                },
+                "fairPlay": {
+                  "properties": {
+                    "level": {
+                      "type": "keyword",
+                      "ignore_above": 256
+                    },
+                    "hdcp": {
+                      "type": "keyword",
+                      "ignore_above": 256
+                    }
+                  }
+                },
+                "playReady": {
+                  "properties": {
+                    "level": {
+                      "type": "keyword",
+                      "ignore_above": 256
+                    },
+                    "hdcp": {
+                      "type": "keyword",
+                      "ignore_above": 256
+                    }
+                  }
+                },
+                "clearKey": {
+                  "properties": {
+                    "level": {
+                      "type": "keyword",
+                      "ignore_above": 256
+                    },
+                    "hdcp": {
+                      "type": "keyword",
+                      "ignore_above": 256
+                    }
+                  }
+                }
+              }
+            },
             "device": {
               "properties": {
                 "id": {

--- a/src/test/kotlin/ch/srgssr/pillarbox/monitoring/opensearch/model/CapabilitiesProcessorTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/monitoring/opensearch/model/CapabilitiesProcessorTest.kt
@@ -1,0 +1,116 @@
+package ch.srgssr.pillarbox.monitoring.opensearch.model
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import org.koin.test.KoinTest
+import org.koin.test.inject
+import tools.jackson.databind.json.JsonMapper
+
+class CapabilitiesProcessorTest :
+  ShouldSpec(),
+  KoinTest {
+  private val jsonMapper by inject<JsonMapper>()
+
+  init {
+    listOf(
+      testCase("SW_SECURE_CRYPTO", "L3"),
+      testCase("SW_SECURE_DECODE", "L3"),
+      testCase("HW_SECURE_CRYPTO", "L2"),
+      testCase("HW_SECURE_DECODE", "L2"),
+      testCase("HW_SECURE_ALL", "L1"),
+      testCase("L2", "L2"),
+    ).forEach { (inputLevel, expectedOutputLevel) ->
+      should("detect map widevine robustness level for $inputLevel") {
+        // Given: an input with widevine capabilities
+        val jsonInput =
+          """
+          {
+            "session_id": "12345",
+            "event_name": "START",
+            "timestamp": 1630000000000,
+            "user_ip": "127.0.0.1",
+            "version": 1,
+            "data": {
+              "capabilities": {
+                "widevine": {
+                  "level": "$inputLevel",
+                  "hdcp": "2.1"
+                }
+              }
+            }
+          }
+          """.trimIndent()
+
+        // When: the event is deserialized
+        val eventRequest =
+          jsonMapper.readValue(
+            jsonInput,
+            EventRequest::class.java,
+          )
+
+        // Then: The level is mapped and the hdcp doesn't change
+        val dataNode = eventRequest.data as Map<*, *>
+        val capabilities = dataNode["capabilities"] as Map<*, *>
+        val widevine = capabilities["widevine"] as Map<*, *>
+
+        widevine["level"] shouldBe expectedOutputLevel
+        // HDCP is not changed
+        widevine["hdcp"] shouldBe "2.1"
+      }
+    }
+
+    listOf(
+      testCase("SW_SECURE_CRYPTO", "SL2000"),
+      testCase("SW_SECURE_DECODE", "SL2000"),
+      testCase("HW_SECURE_CRYPTO", "SL2000"),
+      testCase("HW_SECURE_DECODE", "SL2000"),
+      testCase("HW_SECURE_ALL", "SL3000"),
+      testCase("SL3000", "SL3000"),
+    ).forEach { (inputLevel, expectedOutputLevel) ->
+      should("detect map playReady robustness level for $inputLevel") {
+        // Given: an input with a play ready capabilities
+        val jsonInput =
+          """
+          {
+            "session_id": "12345",
+            "event_name": "START",
+            "timestamp": 1630000000000,
+            "user_ip": "127.0.0.1",
+            "version": 1,
+            "data": {
+              "capabilities": {
+                "playReady": {
+                  "level": "$inputLevel",
+                  "hdcp": "1.0"
+                }
+              }
+            }
+          }
+          """.trimIndent()
+
+        // When: the event is deserialized
+        val eventRequest =
+          jsonMapper.readValue(
+            jsonInput,
+            EventRequest::class.java,
+          )
+
+        // Then: The level is mapped and the hdcp doesn't change
+        val dataNode = eventRequest.data as Map<*, *>
+        val capabilities = dataNode["capabilities"] as Map<*, *>
+        val widevine = capabilities["playReady"] as Map<*, *>
+
+        widevine["level"] shouldBe expectedOutputLevel
+        widevine["hdcp"] shouldBe "1.0"
+      }
+    }
+  }
+}
+
+fun testCase(
+  inputLevel: String,
+  expectedOutputLevel: String,
+) = Pair(
+  inputLevel,
+  expectedOutputLevel,
+)


### PR DESCRIPTION
## Description

Resolves #133 by updating the index schema for the new DRM capabilities fields. Addionally the data processor provides a new capabilities mapper so that clients can sending a robustness level get normalized to a vendor specific level.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
